### PR TITLE
feat: add T keybind to toggle Tax HUD (v1.1.1.0)

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,5 +1,5 @@
 -- =========================================================
--- FS25 Tax Mod (version 1.1.0.0)
+-- FS25 Tax Mod (version 1.1.1.0)
 -- =========================================================
 -- Daily tax deductions with monthly returns
 -- =========================================================
@@ -16,7 +16,7 @@ source(modDirectory .. "src/ui/TaxHUD.lua")
 FS25TaxMod = {}
 FS25TaxMod.modDir  = modDirectory
 FS25TaxMod.modName = modName
-FS25TaxMod.version = "1.1.0.0"
+FS25TaxMod.version = "1.1.1.0"
 FS25TaxMod.Debug   = false
 
 local settings = {
@@ -323,6 +323,42 @@ local function onLoad(mission)
         mission.taxManager = FS25TaxMod
         log("Tax Mod v" .. FS25TaxMod.version .. ": Initialized")
     end
+
+    -- Register T key to toggle HUD via PlayerInputComponent hook (race-condition-safe)
+    if mission:getIsClient() and PlayerInputComponent and PlayerInputComponent.registerActionEvents then
+        local original = PlayerInputComponent.registerActionEvents
+        FS25TaxMod._inputHookOriginal = original
+        PlayerInputComponent.registerActionEvents = function(inputComponent, ...)
+            original(inputComponent, ...)
+            if not (inputComponent.player and inputComponent.player.isOwner) then return end
+            if FS25TaxMod.toggleHUDEventId then return end
+            if not taxHUD then return end
+
+            g_inputBinding:beginActionEventsModification(PlayerInputComponent.INPUT_CONTEXT_NAME)
+            local ok, id = g_inputBinding:registerActionEvent(
+                InputAction.TM_TOGGLE_HUD,
+                FS25TaxMod,
+                FS25TaxMod.onToggleHUDInput,
+                false, true, false, true
+            )
+            if ok and id then
+                FS25TaxMod.toggleHUDEventId = id
+                g_inputBinding:setActionEventTextPriority(id, GS_PRIO_NORMAL)
+                log("HUD toggle (T) registered", 2)
+            else
+                log("HUD toggle (T) registration failed", 1)
+            end
+            g_inputBinding:endActionEventsModification()
+        end
+    end
+end
+
+function FS25TaxMod:onToggleHUDInput()
+    if taxHUD then
+        taxHUD:toggleVisibility()
+        settings.showHUD = taxHUD.visible
+        saveSettings()
+    end
 end
 
 local function onMissionLoaded(mission, node)
@@ -374,6 +410,14 @@ local function onUnload()
     FS25TaxMod.taxSettingsUI = nil
     if FS25TaxMod.updateable and g_currentMission then
         g_currentMission:removeUpdateable(FS25TaxMod.updateable)
+    end
+    if FS25TaxMod.toggleHUDEventId and g_inputBinding then
+        g_inputBinding:removeActionEvent(FS25TaxMod.toggleHUDEventId)
+        FS25TaxMod.toggleHUDEventId = nil
+    end
+    if FS25TaxMod._inputHookOriginal and PlayerInputComponent then
+        PlayerInputComponent.registerActionEvents = FS25TaxMod._inputHookOriginal
+        FS25TaxMod._inputHookOriginal = nil
     end
     saveSettings()
     isInitialized = false
@@ -431,7 +475,7 @@ function taxToggleHUD()   FS25TaxMod:consoleTaxHUD()        end
 function taxDebug(l)      FS25TaxMod:consoleTaxDebug(l)     end
 
 print("========================================")
-print("     FS25 Tax Mod v1.1.0.0 LOADED      ")
+print("     FS25 Tax Mod v1.1.1.0 LOADED      ")
 print("     Author: TisonK                     ")
 print("     Type 'tax' in console for help     ")
 print("========================================")

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -4,7 +4,7 @@
          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/NMC-TBone/xml-schema/main/modDesc.xsd">
 
     <author>TisonK</author>
-    <version>1.1.0.0</version>
+    <version>1.1.1.0</version>
 
     <title>
         <en>Tax Mod</en>
@@ -225,13 +225,33 @@ Funkcje:
             <pl><![CDATA[Pokaż HUD podatkowy]]></pl>
         </text>
         <text name="tm_show_hud_long">
-            <en><![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with taxToggleHUD command)]]></en>
-            <de><![CDATA[Tax-HUD mit aktuellem Steuersatz, Statistiken und letzten Aktivitäten anzeigen (mit taxToggleHUD umschalten)]]></de>
-            <fr><![CDATA[Afficher l'HUD fiscal avec le taux actuel, les statistiques et l'activité récente (basculer avec taxToggleHUD)]]></fr>
-            <es><![CDATA[Mostrar el HUD fiscal con la tasa actual, estadísticas y actividad reciente (alternar con taxToggleHUD)]]></es>
-            <it><![CDATA[Mostra l'HUD fiscale con aliquota corrente, statistiche e attività recente (attiva/disattiva con taxToggleHUD)]]></it>
-            <pl><![CDATA[Pokaż HUD podatkowy z bieżącą stawką, statystykami i ostatnią aktywnością (przełącz komendą taxToggleHUD)]]></pl>
+            <en><![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with T key)]]></en>
+            <de><![CDATA[Tax-HUD mit aktuellem Steuersatz, Statistiken und letzten Aktivitäten anzeigen (mit T umschalten)]]></de>
+            <fr><![CDATA[Afficher l'HUD fiscal avec le taux actuel, les statistiques et l'activité récente (basculer avec T)]]></fr>
+            <es><![CDATA[Mostrar el HUD fiscal con la tasa actual, estadísticas y actividad reciente (alternar con T)]]></es>
+            <it><![CDATA[Mostra l'HUD fiscale con aliquota corrente, statistiche e attività recente (attiva/disattiva con T)]]></it>
+            <pl><![CDATA[Pokaż HUD podatkowy z bieżącą stawką, statystykami i ostatnią aktywnością (przełącz klawiszem T)]]></pl>
+        </text>
+
+        <!-- HUD toggle key binding display name -->
+        <text name="input_TM_TOGGLE_HUD">
+            <en><![CDATA[Toggle Tax HUD]]></en>
+            <de><![CDATA[Steuer-HUD umschalten]]></de>
+            <fr><![CDATA[Basculer l'HUD fiscal]]></fr>
+            <es><![CDATA[Alternar HUD de impuestos]]></es>
+            <it><![CDATA[Attiva/disattiva HUD fiscale]]></it>
+            <pl><![CDATA[Przełącz HUD podatkowy]]></pl>
         </text>
     </l10n>
+
+    <actions>
+        <action name="TM_TOGGLE_HUD" category="ONFOOT" />
+    </actions>
+
+    <inputBinding>
+        <actionBinding action="TM_TOGGLE_HUD">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_T" />
+        </actionBinding>
+    </inputBinding>
 
 </modDesc>

--- a/src/ui/TaxHUD.lua
+++ b/src/ui/TaxHUD.lua
@@ -540,7 +540,7 @@ function TaxHUD:drawPanel()
     if self.editMode then
         renderText(x + w * 0.5, cy - tsSmall, tsSmall, "Drag: move   Corner: resize   RMB: done")
     else
-        renderText(x + w * 0.5, cy - tsSmall, tsSmall, "taxToggleHUD: toggle   RMB: move/resize")
+        renderText(x + w * 0.5, cy - tsSmall, tsSmall, "T: toggle HUD   RMB: move/resize")
     end
 
     -- Reset text state


### PR DESCRIPTION
## Summary
- Registers `TM_TOGGLE_HUD` input action in `modDesc.xml` bound to `KEY_T` by default (player-remappable)
- Hooks `PlayerInputComponent.registerActionEvents` using the same race-condition-safe pattern as IncomeMod
- Cleans up action event and restores original hook on unload
- Updates HUD hint text from console command to key name

## Test plan
- [ ] Load a save — T key toggles Tax HUD on/off
- [ ] HUD visibility persists after toggle (saved to settings XML)
- [ ] Key shows in Controls settings and is remappable
- [ ] No double-registration on level reload
- [ ] Unloading the mod restores `PlayerInputComponent.registerActionEvents`