### PR TITLE
fix: persist HUD layout and visibility on game save (v1.1.2.0)

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,5 +1,5 @@
 -- =========================================================
--- FS25 Tax Mod (version 1.1.1.0)
+-- FS25 Tax Mod (version 1.1.2.0)
 -- =========================================================
 -- Daily tax deductions with monthly returns
 -- =========================================================
@@ -16,7 +16,7 @@ source(modDirectory .. "src/ui/TaxHUD.lua")
 FS25TaxMod = {}
 FS25TaxMod.modDir  = modDirectory
 FS25TaxMod.modName = modName
-FS25TaxMod.version = "1.1.1.0"
+FS25TaxMod.version = "1.1.2.0"
 FS25TaxMod.Debug   = false
 
 local settings = {
@@ -402,6 +402,7 @@ end
 local function onUnload()
     if taxHUD then
         if taxHUD.editMode then taxHUD:exitEditMode() end
+        taxHUD:saveLayout()
         taxHUD:delete()
         taxHUD = nil
         FS25TaxMod.taxHUD = nil
@@ -440,6 +441,7 @@ end)
 
 Mission00.saveToXMLFile = Utils.appendedFunction(Mission00.saveToXMLFile, function(mission, xmlFilename)
     saveSettings()
+    if taxHUD then taxHUD:saveLayout() end
 end)
 
 local taxMouseHandler = {}
@@ -475,7 +477,7 @@ function taxToggleHUD()   FS25TaxMod:consoleTaxHUD()        end
 function taxDebug(l)      FS25TaxMod:consoleTaxDebug(l)     end
 
 print("========================================")
-print("     FS25 Tax Mod v1.1.1.0 LOADED      ")
+print("     FS25 Tax Mod v1.1.2.0 LOADED      ")
 print("     Author: TisonK                     ")
 print("     Type 'tax' in console for help     ")
 print("========================================")

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -4,7 +4,7 @@
          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/NMC-TBone/xml-schema/main/modDesc.xsd">
 
     <author>TisonK</author>
-    <version>1.1.1.0</version>
+    <version>1.1.2.0</version>
 
     <title>
         <en>Tax Mod</en>

--- a/src/ui/TaxHUD.lua
+++ b/src/ui/TaxHUD.lua
@@ -183,9 +183,10 @@ function TaxHUD:saveLayout()
     if not path then return end
     local xml = XMLFile.create("tax_hud", path, "hudLayout")
     if xml then
-        xml:setFloat("hudLayout.posX",  self.posX)
-        xml:setFloat("hudLayout.posY",  self.posY)
-        xml:setFloat("hudLayout.scale", self.scale)
+        xml:setFloat("hudLayout.posX",   self.posX)
+        xml:setFloat("hudLayout.posY",   self.posY)
+        xml:setFloat("hudLayout.scale",  self.scale)
+        xml:setBool("hudLayout.visible", self.visible)
         xml:save()
         xml:delete()
     end
@@ -196,9 +197,10 @@ function TaxHUD:loadLayout()
     if not path or not fileExists(path) then return end
     local xml = XMLFile.load("tax_hud", path)
     if xml then
-        self.posX  = xml:getFloat("hudLayout.posX",  self.posX)
-        self.posY  = xml:getFloat("hudLayout.posY",  self.posY)
-        self.scale = xml:getFloat("hudLayout.scale", self.scale)
+        self.posX    = xml:getFloat("hudLayout.posX",   self.posX)
+        self.posY    = xml:getFloat("hudLayout.posY",   self.posY)
+        self.scale   = xml:getFloat("hudLayout.scale",  self.scale)
+        self.visible = xml:getBool("hudLayout.visible", self.visible)
         xml:delete()
     end
 end


### PR DESCRIPTION
## Summary
- `saveLayout()` is now called on every game save (`Mission00.saveToXMLFile`) and on mod unload
- `saveLayout`/`loadLayout` now persist the `visible` state so T-key toggle survives reloads
- Fixes HUD position, scale, and visibility resetting after saving and reloading

## Test plan
- [ ] Position HUD, save game, reload — position is restored
- [ ] Toggle HUD hidden with T, save game, reload — HUD stays hidden
- [ ] Drag/resize HUD, quit without exiting edit mode, reload — layout is restored