### PR TITLE
Esc RF twin: independence + Crop Stress dial chrome

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -4,7 +4,7 @@
          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/NMC-TBone/xml-schema/main/modDesc.xsd">
 
     <author>TisonK</author>
-    <version>1.1.5.14</version>
+    <version>1.1.5.54</version>
 
     <title>
         <en>Tax Mod</en>
@@ -20,96 +20,96 @@
 Adds realistic tax system to your farm.
 
 Features:
-� Daily tax deductions based on farm balance
-� Monthly tax returns (percentage of taxes paid)
-� Three tax rate levels: Low (1%), Medium (2%), High (3%)
-� Configurable minimum balance threshold
-� Tax history and statistics tracking
-� Professional in-game notifications
-� Fully configurable via console commands
-� Multiplayer compatible
-� Settings saved per savegame
-� Type 'tax' in console for commands
+ï¿½ Daily tax deductions based on farm balance
+ï¿½ Monthly tax returns (percentage of taxes paid)
+ï¿½ Three tax rate levels: Low (1%), Medium (2%), High (3%)
+ï¿½ Configurable minimum balance threshold
+ï¿½ Tax history and statistics tracking
+ï¿½ Professional in-game notifications
+ï¿½ Fully configurable via console commands
+ï¿½ Multiplayer compatible
+ï¿½ Settings saved per savegame
+ï¿½ Type 'tax' in console for commands
 ]]></en>
 
         <de><![CDATA[
-F�gt ein realistisches Steuersystem zu Ihrer Farm hinzu.
+Fï¿½gt ein realistisches Steuersystem zu Ihrer Farm hinzu.
 
 Funktionen:
-� T�gliche Steuerabz�ge basierend auf dem Farmguthaben
-� Monatliche Steuerr�ckzahlungen (Prozentsatz der gezahlten Steuern)
-� Drei Steuersatzstufen: Niedrig (1%), Mittel (2%), Hoch (3%)
-� Konfigurierbare Mindestguthabenschwelle
-� Steuerverlauf und Statistikverfolgung
-� Professionelle In-Game-Benachrichtigungen
-� Vollst�ndig �ber Konsolenbefehle konfigurierbar
-� Multiplayer-kompatibel
-� Einstellungen pro Spielstand gespeichert
-� Geben Sie 'tax' in der Konsole f�r Befehle ein
+ï¿½ Tï¿½gliche Steuerabzï¿½ge basierend auf dem Farmguthaben
+ï¿½ Monatliche Steuerrï¿½ckzahlungen (Prozentsatz der gezahlten Steuern)
+ï¿½ Drei Steuersatzstufen: Niedrig (1%), Mittel (2%), Hoch (3%)
+ï¿½ Konfigurierbare Mindestguthabenschwelle
+ï¿½ Steuerverlauf und Statistikverfolgung
+ï¿½ Professionelle In-Game-Benachrichtigungen
+ï¿½ Vollstï¿½ndig ï¿½ber Konsolenbefehle konfigurierbar
+ï¿½ Multiplayer-kompatibel
+ï¿½ Einstellungen pro Spielstand gespeichert
+ï¿½ Geben Sie 'tax' in der Konsole fï¿½r Befehle ein
 ]]></de>
 
         <fr><![CDATA[
-Ajoute un syst�me de taxes r�aliste � votre ferme.
+Ajoute un systï¿½me de taxes rï¿½aliste ï¿½ votre ferme.
 
-Fonctionnalit�s :
-� D�ductions fiscales quotidiennes bas�es sur le solde de la ferme
-� Remboursements d'imp�ts mensuels (pourcentage des taxes pay�es)
-� Trois niveaux de taux d'imposition : Faible (1%), Moyen (2%), �lev� (3%)
-� Seuil de solde minimum configurable
-� Suivi de l'historique et des statistiques fiscales
-� Notifications professionnelles en jeu
-� Enti�rement configurable via des commandes console
-� Compatible multijoueur
-� Param�tres enregistr�s par partie
-� Tapez 'tax' dans la console pour les commandes
+Fonctionnalitï¿½s :
+ï¿½ Dï¿½ductions fiscales quotidiennes basï¿½es sur le solde de la ferme
+ï¿½ Remboursements d'impï¿½ts mensuels (pourcentage des taxes payï¿½es)
+ï¿½ Trois niveaux de taux d'imposition : Faible (1%), Moyen (2%), ï¿½levï¿½ (3%)
+ï¿½ Seuil de solde minimum configurable
+ï¿½ Suivi de l'historique et des statistiques fiscales
+ï¿½ Notifications professionnelles en jeu
+ï¿½ Entiï¿½rement configurable via des commandes console
+ï¿½ Compatible multijoueur
+ï¿½ Paramï¿½tres enregistrï¿½s par partie
+ï¿½ Tapez 'tax' dans la console pour les commandes
 ]]></fr>
 
         <es><![CDATA[
-A�ade un sistema de impuestos realista a tu granja.
+Aï¿½ade un sistema de impuestos realista a tu granja.
 
-Caracter�sticas:
-� Deducciones fiscales diarias basadas en el saldo de la granja
-� Devoluciones de impuestos mensuales (porcentaje de impuestos pagados)
-� Tres niveles de tasa impositiva: Baja (1%), Media (2%), Alta (3%)
-� Umbral de saldo m�nimo configurable
-� Seguimiento de historial y estad�sticas fiscales
-� Notificaciones profesionales en el juego
-� Totalmente configurable mediante comandos de consola
-� Compatible con multijugador
-� Configuraciones guardadas por partida
-� Escribe 'tax' en la consola para comandos
+Caracterï¿½sticas:
+ï¿½ Deducciones fiscales diarias basadas en el saldo de la granja
+ï¿½ Devoluciones de impuestos mensuales (porcentaje de impuestos pagados)
+ï¿½ Tres niveles de tasa impositiva: Baja (1%), Media (2%), Alta (3%)
+ï¿½ Umbral de saldo mï¿½nimo configurable
+ï¿½ Seguimiento de historial y estadï¿½sticas fiscales
+ï¿½ Notificaciones profesionales en el juego
+ï¿½ Totalmente configurable mediante comandos de consola
+ï¿½ Compatible con multijugador
+ï¿½ Configuraciones guardadas por partida
+ï¿½ Escribe 'tax' en la consola para comandos
 ]]></es>
 
         <it><![CDATA[
 Aggiunge un sistema fiscale realistico alla tua fattoria.
 
 Caratteristiche:
-� Detrazioni fiscali giornaliere basate sul saldo della fattoria
-� Restituzioni fiscali mensili (percentuale delle tasse pagate)
-� Tre livelli di aliquota fiscale: Bassa (1%), Media (2%), Alta (3%)
-� Soglia di saldo minimo configurabile
-� Monitoraggio della cronologia e delle statistiche fiscali
-� Notifiche professionali in gioco
-� Completamente configurabile tramite comandi console
-� Compatibile con il multiplayer
-� Impostazioni salvate per partita
-� Digita 'tax' nella console per i comandi
+ï¿½ Detrazioni fiscali giornaliere basate sul saldo della fattoria
+ï¿½ Restituzioni fiscali mensili (percentuale delle tasse pagate)
+ï¿½ Tre livelli di aliquota fiscale: Bassa (1%), Media (2%), Alta (3%)
+ï¿½ Soglia di saldo minimo configurabile
+ï¿½ Monitoraggio della cronologia e delle statistiche fiscali
+ï¿½ Notifiche professionali in gioco
+ï¿½ Completamente configurabile tramite comandi console
+ï¿½ Compatibile con il multiplayer
+ï¿½ Impostazioni salvate per partita
+ï¿½ Digita 'tax' nella console per i comandi
 ]]></it>
 
         <pl><![CDATA[
 Dodaje realistyczny system podatkowy do Twojej farmy.
 
 Funkcje:
-� Codzienne odliczenia podatkowe na podstawie salda farmy
-� Miesieczne zwroty podatk�w (procent zaplaconych podatk�w)
-� Trzy poziomy stawek podatkowych: Niski (1%), Sredni (2%), Wysoki (3%)
-� Konfigurowalny pr�g minimalnego salda
-� Sledzenie historii i statystyk podatkowych
-� Profesjonalne powiadomienia w grze
-� W pelni konfigurowalne za pomoca komend konsoli
-� Zgodny z trybem wieloosobowym
-� Ustawienia zapisywane per zapis gry
-� Wpisz 'tax' w konsoli dla komend
+ï¿½ Codzienne odliczenia podatkowe na podstawie salda farmy
+ï¿½ Miesieczne zwroty podatkï¿½w (procent zaplaconych podatkï¿½w)
+ï¿½ Trzy poziomy stawek podatkowych: Niski (1%), Sredni (2%), Wysoki (3%)
+ï¿½ Konfigurowalny prï¿½g minimalnego salda
+ï¿½ Sledzenie historii i statystyk podatkowych
+ï¿½ Profesjonalne powiadomienia w grze
+ï¿½ W pelni konfigurowalne za pomoca komend konsoli
+ï¿½ Zgodny z trybem wieloosobowym
+ï¿½ Ustawienia zapisywane per zapis gry
+ï¿½ Wpisz 'tax' w konsoli dla komend
 ]]></pl>
     </description>
 
@@ -168,8 +168,8 @@ Funkcje:
         </text>
         <text name="tm_enabled_long">
             <en><![CDATA[Enable or disable daily tax deductions and monthly returns]]></en>
-            <de><![CDATA[T�gliche Steuerabz�ge und monatliche R�ckerstattungen ein-/ausschalten]]></de>
-            <fr><![CDATA[Activer ou d�sactiver les d�ductions fiscales quotidiennes et les remboursements mensuels]]></fr>
+            <de><![CDATA[Tï¿½gliche Steuerabzï¿½ge und monatliche Rï¿½ckerstattungen ein-/ausschalten]]></de>
+            <fr><![CDATA[Activer ou dï¿½sactiver les dï¿½ductions fiscales quotidiennes et les remboursements mensuels]]></fr>
             <es><![CDATA[Activar o desactivar las deducciones fiscales diarias y las devoluciones mensuales]]></es>
             <it><![CDATA[Attiva o disattiva le detrazioni fiscali giornaliere e i rimborsi mensili]]></it>
             <pl><![CDATA[Wlacz lub wylacz codzienne odliczenia podatkowe i miesieczne zwroty]]></pl>
@@ -178,7 +178,7 @@ Funkcje:
             <cz>[EN] <![CDATA[Enable or disable daily tax deductions and monthly returns]]></cz>
             <br>[EN] <![CDATA[Enable or disable daily tax deductions and monthly returns]]></br>
             <ru>[EN] <![CDATA[Enable or disable daily tax deductions and monthly returns]]></ru>
-            <da><![CDATA[Aktiv�r eller deaktiver daglige skattefradrag og m�nedlige skatterefusioner]]></da>
+            <da><![CDATA[Aktivï¿½r eller deaktiver daglige skattefradrag og mï¿½nedlige skatterefusioner]]></da>
         </text>
 
         <!-- Tax Rate -->
@@ -198,8 +198,8 @@ Funkcje:
         </text>
         <text name="tm_taxrate_long">
             <en><![CDATA[Daily tax rate applied to your farm balance: Low=1%, Medium=2%, High=3%]]></en>
-            <de><![CDATA[T�glicher Steuersatz auf Ihr Farmguthaben: Niedrig=1%, Mittel=2%, Hoch=3%]]></de>
-            <fr><![CDATA[Taux d'imposition quotidien appliqu� � votre solde: Faible=1%, Moyen=2%, �lev�=3%]]></fr>
+            <de><![CDATA[Tï¿½glicher Steuersatz auf Ihr Farmguthaben: Niedrig=1%, Mittel=2%, Hoch=3%]]></de>
+            <fr><![CDATA[Taux d'imposition quotidien appliquï¿½ ï¿½ votre solde: Faible=1%, Moyen=2%, ï¿½levï¿½=3%]]></fr>
             <es><![CDATA[Tasa impositiva diaria sobre el saldo de tu granja: Baja=1%, Media=2%, Alta=3%]]></es>
             <it><![CDATA[Aliquota fiscale giornaliera sul saldo della fattoria: Bassa=1%, Media=2%, Alta=3%]]></it>
             <pl><![CDATA[Dzienna stawka podatkowa od salda farmy: Niska=1%, Srednia=2%, Wysoka=3%]]></pl>
@@ -208,7 +208,7 @@ Funkcje:
             <cz>[EN] <![CDATA[Daily tax rate applied to your farm balance: Low=1%, Medium=2%, High=3%]]></cz>
             <br>[EN] <![CDATA[Daily tax rate applied to your farm balance: Low=1%, Medium=2%, High=3%]]></br>
             <ru>[EN] <![CDATA[Daily tax rate applied to your farm balance: Low=1%, Medium=2%, High=3%]]></ru>
-            <da><![CDATA[Daglig skattesats anvendt p� din g�rds saldo: Lav=1 %, Mellem=2 %, H�j=3 %]]></da>
+            <da><![CDATA[Daglig skattesats anvendt pï¿½ din gï¿½rds saldo: Lav=1 %, Mellem=2 %, Hï¿½j=3 %]]></da>
         </text>
         <text name="tm_taxrate_1"><en><![CDATA[Low (1%)]]></en><de><![CDATA[Niedrig (1%)]]></de><fr><![CDATA[Faible (1%)]]></fr><es><![CDATA[Baja (1%)]]></es><it><![CDATA[Bassa (1%)]]></it><pl><![CDATA[Niska (1%)]]></pl><uk><![CDATA[?????? (1%)]]></uk>
             <cz>[EN] <![CDATA[Low (1%)]]></cz>
@@ -222,17 +222,17 @@ Funkcje:
             <ru>[EN] <![CDATA[Medium (2%)]]></ru>
             <da><![CDATA[Mellem (2 %)]]></da>
         </text>
-        <text name="tm_taxrate_3"><en><![CDATA[High (3%)]]></en><de><![CDATA[Hoch (3%)]]></de><fr><![CDATA[�lev� (3%)]]></fr><es><![CDATA[Alta (3%)]]></es><it><![CDATA[Alta (3%)]]></it><pl><![CDATA[Wysoka (3%)]]></pl><uk><![CDATA[?????? (3%)]]></uk>
+        <text name="tm_taxrate_3"><en><![CDATA[High (3%)]]></en><de><![CDATA[Hoch (3%)]]></de><fr><![CDATA[ï¿½levï¿½ (3%)]]></fr><es><![CDATA[Alta (3%)]]></es><it><![CDATA[Alta (3%)]]></it><pl><![CDATA[Wysoka (3%)]]></pl><uk><![CDATA[?????? (3%)]]></uk>
             <cz>[EN] <![CDATA[High (3%)]]></cz>
             <br>[EN] <![CDATA[High (3%)]]></br>
             <ru>[EN] <![CDATA[High (3%)]]></ru>
-            <da><![CDATA[H�j (3 %)]]></da>
+            <da><![CDATA[Hï¿½j (3 %)]]></da>
         </text>
 
         <!-- Annual Tax Rate -->
         <text name="tm_annualrate_short">
             <en><![CDATA[Annual Tax Rate]]></en>
-            <de><![CDATA[J�hrlicher Steuersatz]]></de>
+            <de><![CDATA[Jï¿½hrlicher Steuersatz]]></de>
             <fr><![CDATA[Taux d'imposition annuel]]></fr>
             <es><![CDATA[Tasa impositiva anual]]></es>
             <it><![CDATA[Aliquota fiscale annuale]]></it>
@@ -242,21 +242,21 @@ Funkcje:
             <cz>[EN] <![CDATA[Annual Tax Rate]]></cz>
             <br>[EN] <![CDATA[Annual Tax Rate]]></br>
             <ru>[EN] <![CDATA[Annual Tax Rate]]></ru>
-            <da><![CDATA[�rlig skattesats]]></da>
+            <da><![CDATA[ï¿½rlig skattesats]]></da>
         </text>
         <text name="tm_annualrate_long">
             <en><![CDATA[Percentage of accumulated taxes paid each March: Low=2%, Medium=5%, High=10%]]></en>
-            <de><![CDATA[Prozentsatz der angesammelten Steuern, der jeden M�rz gezahlt wird: Niedrig=2%, Mittel=5%, Hoch=10%]]></de>
-            <fr><![CDATA[Pourcentage des taxes accumul�es pay�es chaque mars: Faible=2%, Moyen=5%, �lev�=10%]]></fr>
+            <de><![CDATA[Prozentsatz der angesammelten Steuern, der jeden Mï¿½rz gezahlt wird: Niedrig=2%, Mittel=5%, Hoch=10%]]></de>
+            <fr><![CDATA[Pourcentage des taxes accumulï¿½es payï¿½es chaque mars: Faible=2%, Moyen=5%, ï¿½levï¿½=10%]]></fr>
             <es><![CDATA[Porcentaje de impuestos acumulados pagados cada marzo: Baja=2%, Media=5%, Alta=10%]]></es>
             <it><![CDATA[Percentuale delle tasse accumulate pagate ogni marzo: Bassa=2%, Media=5%, Alta=10%]]></it>
-            <pl><![CDATA[Procent zgromadzonych podatk�w placonych kazdego marca: Niski=2%, Sredni=5%, Wysoki=10%]]></pl>
+            <pl><![CDATA[Procent zgromadzonych podatkï¿½w placonych kazdego marca: Niski=2%, Sredni=5%, Wysoki=10%]]></pl>
             <uk><![CDATA[???????? ??????????? ????????, ?? ??????????? ??????? ???????: ???????=2%, ????????=5%, ???????=10%]]></uk>
         
             <cz>[EN] <![CDATA[Percentage of accumulated taxes paid each March: Low=2%, Medium=5%, High=10%]]></cz>
             <br>[EN] <![CDATA[Percentage of accumulated taxes paid each March: Low=2%, Medium=5%, High=10%]]></br>
             <ru>[EN] <![CDATA[Percentage of accumulated taxes paid each March: Low=2%, Medium=5%, High=10%]]></ru>
-            <da><![CDATA[Procentdel af de akkumulerede skatter, der udbetales hver marts: Lav=2 %, Mellem=5 %, H�j=10 %]]></da>
+            <da><![CDATA[Procentdel af de akkumulerede skatter, der udbetales hver marts: Lav=2 %, Mellem=5 %, Hï¿½j=10 %]]></da>
         </text>
         <text name="tm_annualrate_1"><en><![CDATA[Low (2%)]]></en><de><![CDATA[Niedrig (2%)]]></de><fr><![CDATA[Faible (2%)]]></fr><es><![CDATA[Baja (2%)]]></es><it><![CDATA[Bassa (2%)]]></it><pl><![CDATA[Niski (2%)]]></pl><uk><![CDATA[??????? (2%)]]></uk>
             <cz>[EN] <![CDATA[Low (2%)]]></cz>
@@ -270,19 +270,19 @@ Funkcje:
             <ru>[EN] <![CDATA[Medium (5%)]]></ru>
             <da><![CDATA[Mellem (5 %)]]></da>
         </text>
-        <text name="tm_annualrate_3"><en><![CDATA[High (10%)]]></en><de><![CDATA[Hoch (10%)]]></de><fr><![CDATA[�lev� (10%)]]></fr><es><![CDATA[Alta (10%)]]></es><it><![CDATA[Alta (10%)]]></it><pl><![CDATA[Wysoki (10%)]]></pl><uk><![CDATA[??????? (10%)]]></uk>
+        <text name="tm_annualrate_3"><en><![CDATA[High (10%)]]></en><de><![CDATA[Hoch (10%)]]></de><fr><![CDATA[ï¿½levï¿½ (10%)]]></fr><es><![CDATA[Alta (10%)]]></es><it><![CDATA[Alta (10%)]]></it><pl><![CDATA[Wysoki (10%)]]></pl><uk><![CDATA[??????? (10%)]]></uk>
             <cz>[EN] <![CDATA[High (10%)]]></cz>
             <br>[EN] <![CDATA[High (10%)]]></br>
             <ru>[EN] <![CDATA[High (10%)]]></ru>
-            <da><![CDATA[H�j (10 %)]]></da>
+            <da><![CDATA[Hï¿½j (10 %)]]></da>
         </text>
 
         <!-- Return Percentage (kept for save compatibility) -->
         <text name="tm_return_short">
             <en><![CDATA[Tax Return %]]></en>
-            <de><![CDATA[Steuerr�ckerstattung %]]></de>
+            <de><![CDATA[Steuerrï¿½ckerstattung %]]></de>
             <fr><![CDATA[Remboursement fiscal %]]></fr>
-            <es><![CDATA[% Devoluci�n de impuestos]]></es>
+            <es><![CDATA[% Devoluciï¿½n de impuestos]]></es>
             <it><![CDATA[% Rimborso fiscale]]></it>
             <pl><![CDATA[% Zwrotu podatku]]></pl>
             <uk><![CDATA[% ?????????? ???????]]></uk>
@@ -294,17 +294,17 @@ Funkcje:
         </text>
         <text name="tm_return_long">
             <en><![CDATA[Percentage of monthly taxes returned at the start of each new month: Low=10%, Medium=20%, High=30%]]></en>
-            <de><![CDATA[Prozentsatz der monatlichen Steuern, der zur�ckerstattet wird: Niedrig=10%, Mittel=20%, Hoch=30%]]></de>
-            <fr><![CDATA[Pourcentage des taxes mensuelles rembours�es: Faible=10%, Moyen=20%, �lev�=30%]]></fr>
+            <de><![CDATA[Prozentsatz der monatlichen Steuern, der zurï¿½ckerstattet wird: Niedrig=10%, Mittel=20%, Hoch=30%]]></de>
+            <fr><![CDATA[Pourcentage des taxes mensuelles remboursï¿½es: Faible=10%, Moyen=20%, ï¿½levï¿½=30%]]></fr>
             <es><![CDATA[Porcentaje de impuestos mensuales devueltos: Baja=10%, Media=20%, Alta=30%]]></es>
             <it><![CDATA[Percentuale delle tasse mensili rimborsate: Bassa=10%, Media=20%, Alta=30%]]></it>
-            <pl><![CDATA[Procent miesiecznych podatk�w zwracanych: Niski=10%, Sredni=20%, Wysoki=30%]]></pl>
+            <pl><![CDATA[Procent miesiecznych podatkï¿½w zwracanych: Niski=10%, Sredni=20%, Wysoki=30%]]></pl>
             <uk><![CDATA[???????? ???????? ????????, ?? ???????????? ?? ??????? ??????: ???????=10%, ????????=20%, ???????=30%]]></uk>
         
             <cz>[EN] <![CDATA[Percentage of monthly taxes returned at the start of each new month: Low=10%, Medium=20%, High=30%]]></cz>
             <br>[EN] <![CDATA[Percentage of monthly taxes returned at the start of each new month: Low=10%, Medium=20%, High=30%]]></br>
             <ru>[EN] <![CDATA[Percentage of monthly taxes returned at the start of each new month: Low=10%, Medium=20%, High=30%]]></ru>
-            <da><![CDATA[Procentdel af de m�nedlige skatter, der tilbagebetales ved starten af hver ny m�ned: Lav=10 %, Mellem=20 %, H�j=30 %]]></da>
+            <da><![CDATA[Procentdel af de mï¿½nedlige skatter, der tilbagebetales ved starten af hver ny mï¿½ned: Lav=10 %, Mellem=20 %, Hï¿½j=30 %]]></da>
         </text>
         <text name="tm_return_1"><en><![CDATA[Low (10%)]]></en><de><![CDATA[Niedrig (10%)]]></de><fr><![CDATA[Faible (10%)]]></fr><es><![CDATA[Baja (10%)]]></es><it><![CDATA[Bassa (10%)]]></it><pl><![CDATA[Niski (10%)]]></pl><uk><![CDATA[??????? (10%)]]></uk>
             <cz>[EN] <![CDATA[Low (10%)]]></cz>
@@ -318,11 +318,11 @@ Funkcje:
             <ru>[EN] <![CDATA[Medium (20%)]]></ru>
             <da><![CDATA[Mellem (20 %)]]></da>
         </text>
-        <text name="tm_return_3"><en><![CDATA[High (30%)]]></en><de><![CDATA[Hoch (30%)]]></de><fr><![CDATA[�lev� (30%)]]></fr><es><![CDATA[Alta (30%)]]></es><it><![CDATA[Alta (30%)]]></it><pl><![CDATA[Wysoki (30%)]]></pl><uk><![CDATA[??????? (30%)]]></uk>
+        <text name="tm_return_3"><en><![CDATA[High (30%)]]></en><de><![CDATA[Hoch (30%)]]></de><fr><![CDATA[ï¿½levï¿½ (30%)]]></fr><es><![CDATA[Alta (30%)]]></es><it><![CDATA[Alta (30%)]]></it><pl><![CDATA[Wysoki (30%)]]></pl><uk><![CDATA[??????? (30%)]]></uk>
             <cz>[EN] <![CDATA[High (30%)]]></cz>
             <br>[EN] <![CDATA[High (30%)]]></br>
             <ru>[EN] <![CDATA[High (30%)]]></ru>
-            <da><![CDATA[H�j (30 %)]]></da>
+            <da><![CDATA[Hï¿½j (30 %)]]></da>
         </text>
 
         <!-- Notifications -->
@@ -342,8 +342,8 @@ Funkcje:
         </text>
         <text name="tm_notifications_long">
             <en><![CDATA[Show in-game notifications when taxes are deducted or returns are paid]]></en>
-            <de><![CDATA[In-Game-Benachrichtigungen anzeigen, wenn Steuern abgezogen oder R�ckerstattungen gezahlt werden]]></de>
-            <fr><![CDATA[Afficher les notifications en jeu lors des d�ductions fiscales ou des remboursements]]></fr>
+            <de><![CDATA[In-Game-Benachrichtigungen anzeigen, wenn Steuern abgezogen oder Rï¿½ckerstattungen gezahlt werden]]></de>
+            <fr><![CDATA[Afficher les notifications en jeu lors des dï¿½ductions fiscales ou des remboursements]]></fr>
             <es><![CDATA[Mostrar notificaciones en el juego cuando se deducen impuestos o se pagan devoluciones]]></es>
             <it><![CDATA[Mostra notifiche in gioco quando vengono detratte le tasse o pagati i rimborsi]]></it>
             <pl><![CDATA[Pokazuj powiadomienia w grze gdy podatki sa odliczane lub zwracane]]></pl>
@@ -352,7 +352,7 @@ Funkcje:
             <cz>[EN] <![CDATA[Show in-game notifications when taxes are deducted or returns are paid]]></cz>
             <br>[EN] <![CDATA[Show in-game notifications when taxes are deducted or returns are paid]]></br>
             <ru>[EN] <![CDATA[Show in-game notifications when taxes are deducted or returns are paid]]></ru>
-            <da><![CDATA[Vis notifikationer i spillet, n�r skatter fratr�kkes eller refusioner udbetales]]></da>
+            <da><![CDATA[Vis notifikationer i spillet, nï¿½r skatter fratrï¿½kkes eller refusioner udbetales]]></da>
         </text>
 
         <!-- Show HUD -->
@@ -372,17 +372,17 @@ Funkcje:
         </text>
         <text name="tm_show_hud_long">
             <en><![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with T key)]]></en>
-            <de><![CDATA[Tax-HUD mit aktuellem Steuersatz, Statistiken und letzten Aktivit�ten anzeigen (mit T umschalten)]]></de>
-            <fr><![CDATA[Afficher l'HUD fiscal avec le taux actuel, les statistiques et l'activit� r�cente (basculer avec T)]]></fr>
-            <es><![CDATA[Mostrar el HUD fiscal con la tasa actual, estad�sticas y actividad reciente (alternar con T)]]></es>
-            <it><![CDATA[Mostra l'HUD fiscale con aliquota corrente, statistiche e attivit� recente (attiva/disattiva con T)]]></it>
+            <de><![CDATA[Tax-HUD mit aktuellem Steuersatz, Statistiken und letzten Aktivitï¿½ten anzeigen (mit T umschalten)]]></de>
+            <fr><![CDATA[Afficher l'HUD fiscal avec le taux actuel, les statistiques et l'activitï¿½ rï¿½cente (basculer avec T)]]></fr>
+            <es><![CDATA[Mostrar el HUD fiscal con la tasa actual, estadï¿½sticas y actividad reciente (alternar con T)]]></es>
+            <it><![CDATA[Mostra l'HUD fiscale con aliquota corrente, statistiche e attivitï¿½ recente (attiva/disattiva con T)]]></it>
             <pl><![CDATA[Pokaz HUD podatkowy z biezaca stawka, statystykami i ostatnia aktywnoscia (przelacz klawiszem T)]]></pl>
             <uk><![CDATA[???????? HUD ???????? ? ???????? ???????, ??????????? ?? ??????????? ?????????? (?????????? ???????? T)]]></uk>
         
             <cz>[EN] <![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with T key)]]></cz>
             <br>[EN] <![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with T key)]]></br>
             <ru>[EN] <![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with T key)]]></ru>
-            <da><![CDATA[Vis skatte-HUD-overlayet med aktuel sats, statistik og seneste aktivitet (sl� til/fra med T-tasten)]]></da>
+            <da><![CDATA[Vis skatte-HUD-overlayet med aktuel sats, statistik og seneste aktivitet (slï¿½ til/fra med T-tasten)]]></da>
         </text>
 
         <!-- HUD toggle key binding display name -->
@@ -397,7 +397,7 @@ Funkcje:
             <cz>[EN] <![CDATA[Toggle Tax HUD]]></cz>
             <br>[EN] <![CDATA[Toggle Tax HUD]]></br>
             <ru>[EN] <![CDATA[Toggle Tax HUD]]></ru>
-            <da><![CDATA[Sl� skatte-HUD til/fra]]></da>
+            <da><![CDATA[Slï¿½ skatte-HUD til/fra]]></da>
         </text>
         <text name="input_TM_HUD_DRAG">
             <en>Tax HUD Edit Mode</en>
@@ -821,32 +821,32 @@ Funkcje:
             <vi><![CDATA[[EN] Tax posture glance: on/off, bill, March, balance share, countdown, lifetime paid, ledger summary.]]></vi>
         </text>
         <text name="tax_rf_pda_hint_rates">
-            <en><![CDATA[Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></en>
-            <de><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></de>
-            <fr><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></fr>
-            <pl><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></pl>
-            <es><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></es>
-            <it><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></it>
-            <cz><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></cz>
-            <br><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></br>
-            <uk><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></uk>
-            <ru><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></ru>
-            <da><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></da>
-            <ct><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></ct>
-            <ea><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></ea>
-            <fc><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></fc>
-            <fi><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></fi>
-            <hu><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></hu>
-            <id><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></id>
-            <jp><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></jp>
-            <kr><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></kr>
-            <nl><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></nl>
-            <no><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></no>
-            <pt><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></pt>
-            <ro><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></ro>
-            <sv><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></sv>
-            <tr><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></tr>
-            <vi><![CDATA[[EN] Daily rate: %s (%.0f%%) · March rate: %.0f%% · Min balance: %s]]></vi>
+            <en><![CDATA[Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></en>
+            <de><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></de>
+            <fr><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></fr>
+            <pl><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></pl>
+            <es><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></es>
+            <it><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></it>
+            <cz><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></cz>
+            <br><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></br>
+            <uk><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></uk>
+            <ru><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></ru>
+            <da><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></da>
+            <ct><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></ct>
+            <ea><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></ea>
+            <fc><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></fc>
+            <fi><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></fi>
+            <hu><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></hu>
+            <id><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></id>
+            <jp><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></jp>
+            <kr><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></kr>
+            <nl><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></nl>
+            <no><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></no>
+            <pt><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></pt>
+            <ro><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></ro>
+            <sv><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></sv>
+            <tr><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></tr>
+            <vi><![CDATA[[EN] Daily rate: %s (%.0f%%) Â· March rate: %.0f%% Â· Min balance: %s]]></vi>
         </text>
         <text name="tax_rf_pda_lbl_min_balance">
             <en><![CDATA[Min balance]]></en>

--- a/src/gui/RfEscModules.lua
+++ b/src/gui/RfEscModules.lua
@@ -4,10 +4,28 @@
 -- Law: Ash Office/NOTE-Wizard-Esc-NO-HOST-module-stack-LAW-2026-08-02.md
 -- Published ONLY on g_currentMission.rfEscModules (+ env g_rfEscModules).
 -- Never rfPdaHost / elected Soil owner.
+-- Module home (2026-08-09): cold → soilFertilizer; session last-closed;
+-- optional SettingsHub escLastModuleId (enum soft-detect). First-register
+-- lottery is NOT the product default.
 -- =========================================================
 
 RfEscModules = {}
 local RfEscModules_mt = Class(RfEscModules)
+
+local HUB_MOD_ID = "RfEsc"
+local HUB_KEY = "escLastModuleId"
+-- SettingsHub validates enum only (no freeform string). Keep in sync with joiners.
+local HUB_ENUM = {
+    "soilFertilizer",
+    "workerCosts",
+    "seasonalCropStress",
+    "marketDynamics",
+    "income",
+    "tax",
+    "dairy",
+    "npcFavor",
+    "fertilizerDepot",
+}
 
 local function _publish(reg)
     local env = getfenv(0)
@@ -24,6 +42,9 @@ function RfEscModules.new()
     local self = setmetatable({}, RfEscModules_mt)
     self.modules = {}
     self.activeModuleId = nil
+    self._lastClosedModuleId = nil
+    self._userHasChosenModule = false
+    self._settingsHubBound = false
     self.listeners = {}
     return self
 end
@@ -53,6 +74,139 @@ function RfEscModules:_notify()
     end
 end
 
+---@param id string|nil
+---@return boolean
+function RfEscModules:_moduleAvailable(id)
+    if id == nil or id == "" then
+        return false
+    end
+    local def = self.modules[id]
+    if def == nil then
+        return false
+    end
+    local ok, available = pcall(def.isAvailable)
+    return ok and available == true
+end
+
+function RfEscModules:_ensureSettingsHub()
+    if self._settingsHubBound then
+        return
+    end
+    local hub = g_currentMission ~= nil and g_currentMission.settingsHub or nil
+    if hub == nil or type(hub.registerModule) ~= "function" then
+        return
+    end
+    local reg = self
+    local ok = pcall(function()
+        hub:registerModule(HUB_MOD_ID, {
+            adminSettings = {
+                {
+                    id = HUB_KEY,
+                    type = "enum",
+                    values = HUB_ENUM,
+                    default = "soilFertilizer",
+                    adminOnly = false,
+                    label = "Esc RF last module",
+                },
+            },
+            onChange = function(key, value)
+                if key == HUB_KEY and type(value) == "string" and value ~= "" then
+                    reg._lastClosedModuleId = value
+                    reg._userHasChosenModule = true
+                end
+            end,
+        })
+    end)
+    self._settingsHubBound = ok == true
+end
+
+---@return string|nil
+function RfEscModules:_readHubLastModuleId()
+    self:_ensureSettingsHub()
+    local hub = g_currentMission ~= nil and g_currentMission.settingsHub or nil
+    if hub == nil or type(hub.getValue) ~= "function" then
+        return nil
+    end
+    local ok, value = pcall(function()
+        return hub:getValue(HUB_MOD_ID, HUB_KEY)
+    end)
+    if ok and type(value) == "string" and value ~= "" then
+        return value
+    end
+    return nil
+end
+
+---@param id string
+function RfEscModules:_writeHubLastModuleId(id)
+    if id == nil or id == "" then
+        return
+    end
+    local allowed = false
+    for _, v in ipairs(HUB_ENUM) do
+        if v == id then
+            allowed = true
+            break
+        end
+    end
+    if not allowed then
+        return
+    end
+    self:_ensureSettingsHub()
+    local hub = g_currentMission ~= nil and g_currentMission.settingsHub or nil
+    if hub == nil or type(hub.setValue) ~= "function" then
+        return
+    end
+    pcall(function()
+        hub:setValue(HUB_MOD_ID, HUB_KEY, id)
+    end)
+end
+
+--- Cold / reopen home: session last → SettingsHub durable → Soil → first sorted.
+---@return string|nil
+function RfEscModules:resolveHomeModuleId()
+    if self:_moduleAvailable(self._lastClosedModuleId) then
+        return self._lastClosedModuleId
+    end
+    local hubId = self:_readHubLastModuleId()
+    if self:_moduleAvailable(hubId) then
+        return hubId
+    end
+    if self:_moduleAvailable("soilFertilizer") then
+        return "soilFertilizer"
+    end
+    local list = self:getModules()
+    if list[1] ~= nil then
+        return list[1].id
+    end
+    return nil
+end
+
+--- Persist last module (select + frame close). Soft-detect SettingsHub write.
+---@param id string|nil
+function RfEscModules:rememberClosedModule(id)
+    if id == nil or id == "" then
+        return
+    end
+    if self.modules[id] == nil then
+        return
+    end
+    self._lastClosedModuleId = id
+    self._userHasChosenModule = true
+    self:_writeHubLastModuleId(id)
+end
+
+--- Apply home without listener notify (single onShow on subsequent refreshContent).
+---@return boolean
+function RfEscModules:applyHomeModuleQuiet()
+    local id = self:resolveHomeModuleId()
+    if id == nil then
+        return false
+    end
+    self.activeModuleId = id
+    self._userHasChosenModule = true
+    return true
+end
+
 --- Register or replace a module joiner.
 ---@param def table { id, title, order, icon?, blurb?, isAvailable, onShow, onHide?, onWageOptionChanged?, onWageReset? }
 function RfEscModules:registerModule(def)
@@ -70,10 +224,50 @@ function RfEscModules:registerModule(def)
         onHide = def.onHide,
         onWageOptionChanged = def.onWageOptionChanged,
         onWageReset = def.onWageReset,
+        -- Vera F2 2026-08-07: registerModule whitelists fields, so this was being
+        -- dropped and the door could never ask the active module to open its own
+        -- deep screen. Guests register it; keep it.
+        onOpenFullMarket = def.onOpenFullMarket,
+        -- Same trap, 2026-08-09: a handler missing from this list is silently
+        -- discarded and the Esc Crop Stress buttons would do nothing.
+        onOpenConsultant = def.onOpenConsultant,
+        onOpenSchedule = def.onOpenSchedule,
+        onPaintConsultant = def.onPaintConsultant,
+        -- Same trap again, BUILD 15:46: the CS guest registers onPivotRemote on
+        -- its module def (CsRfPdaGuest.lua) but it was missing here, so it was
+        -- silently discarded and active.onPivotRemote was always nil. The Esc
+        -- PIVOT buttons only worked through the global CsRfPdaGuest fallback.
+        onPivotRemote = def.onPivotRemote,
+        -- Fourth time, BUILD 23:51 (Vera F1/F2): the MD guest registers onLightTick for
+        -- the quiet 2s price refresh. Without it here the field was dropped, so
+        -- active.onLightTick was nil and every soft refresh fell back to the fat onShow -
+        -- which made the whole 23:43 soft path a no-op.
+        -- Fifth instance, found by the warning below on its first run: the MD guest has
+        -- always registered onMoverChanged and it has always been dropped. Nothing in the
+        -- suite consumes it today, so carrying it is a one-line no-risk fix - safer than
+        -- deleting a registration in case a consumer turns up - and it keeps the new
+        -- warning meaningful instead of crying wolf every session.
+        onMoverChanged = def.onMoverChanged,
+        -- BUILD 12:59 independence contract: a guest that registers its own selection
+        -- callback can be driven straight off the registry, so the host never has to find
+        -- the guest object at all. That is the level that works with no globals, no env
+        -- scanning and no mod names; the resolver in the host is only the fallback for
+        -- companions that predate this.
+        selectCommodityIndex = def.selectCommodityIndex,
+        onLightTick = def.onLightTick,
     }
-    if self.activeModuleId == nil then
-        self.activeModuleId = def.id
+    -- BUILD 23:51: this whitelist has now silently eaten a handler four times, so stop
+    -- letting it do that quietly. Anything a caller passed that is not carried above gets
+    -- named once, at register time, instead of turning into a handler that does nothing.
+    for k in pairs(def) do
+        if self.modules[def.id][k] == nil and def[k] ~= nil then
+            print(string.format(
+                "[RfEscModules] WARNING module '%s' passed '%s' but registerModule does not carry it - dropped",
+                tostring(def.id), tostring(k)))
+        end
     end
+    -- Product default is resolveHomeModuleId (Soil / last / hub), not first-register.
+    -- Leave activeModuleId nil until applyHomeModuleQuiet / selectModule.
     self:_notify()
     return true
 end
@@ -90,9 +284,14 @@ function RfEscModules:unregisterModule(id)
     self.modules[id] = nil
     if wasActive then
         self.activeModuleId = nil
-        local list = self:getModules()
-        if list[1] ~= nil then
-            self.activeModuleId = list[1].id
+        local home = self:resolveHomeModuleId()
+        if home ~= nil then
+            self.activeModuleId = home
+        else
+            local list = self:getModules()
+            if list[1] ~= nil then
+                self.activeModuleId = list[1].id
+            end
         end
     end
     self:_notify()
@@ -134,6 +333,7 @@ function RfEscModules:selectModule(id)
         return false
     end
     self.activeModuleId = id
+    self:rememberClosedModule(id)
     self:_notify()
     return true
 end

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -168,6 +168,62 @@ end
 
 --- Resolve l10n with English fallback. When CS/WC create the Esc door, MOD_NAME
 --- i18n may lack Soil table keys - also probe Soil modEnv, then g_i18n.
+--- BUILD 21:41 cross-mod resolve for Market Dynamics classes.
+--- The RfPdaMenuPage that actually runs belongs to whichever mod won the NO-HOST door
+--- race, so bare MDMMarketScreenGraph / MdRfPdaGuest are nil in every environment except
+--- MarketDynamics' own - that is why the Prices graph vanished when Dairy hosted the door.
+--- Same shape as the Open Market resolve below: read the bare global in the caller's env
+--- first, then fall back to g_modEnvironments. Never invents a class it cannot find.
+---
+--- BUILD 22:04: this MUST stay above draw/update/onListSelectionChanged. It was defined
+--- near resolveListRowIndex at first, which is ~1900 lines BELOW the draw call, and a Lua
+--- local is nil before its definition - so draw called a nil global once per frame and
+--- took the Esc rail down with it. Kept next to the other cross-mod resolvers so its
+--- ordering requirement is obvious.
+local function mdResolve(bare, name)
+    -- 1. in-env: free when MarketDynamics itself is the host.
+    if bare ~= nil then
+        return bare
+    end
+    -- 2. the named environment. Kept first among the fallbacks because it is the cheapest
+    --    and correct in the common case, but NOT trusted alone - this hardcodes a mod name
+    --    the guest itself never hardcodes (it uses g_currentModName), so a rename or a
+    --    differently-named install slips straight past it. That is what produced
+    --    "GATE graph=false" on the Dairy door.
+    if g_modEnvironments ~= nil then
+        -- BUILD 12:59: owner per name. This belt used to hardcode MarketDynamics, so every
+        -- other suite class fell straight past it to the scan. Crop Stress and the Market
+        -- screen now get the same cheap first-guess Market Dynamics always had.
+        local OWNER = {
+            MdRfPdaGuest = "FS25_MarketDynamics",
+            MDMMarketScreenGraph = "FS25_MarketDynamics",
+            MDMMarketScreen = "FS25_MarketDynamics",
+            CsRfPdaGuest = "FS25_SeasonalCropStress",
+        }
+        local env = g_modEnvironments[OWNER[name] or "FS25_MarketDynamics"]
+        if env ~= nil and env[name] ~= nil then
+            return env[name]
+        end
+        -- 3. key-independent scan: ask every loaded mod environment whether it carries the
+        --    class. No name guessing, so a rename cannot break this belt.
+        for _, e in pairs(g_modEnvironments) do
+            if type(e) == "table" and e[name] ~= nil then
+                return e[name]
+            end
+        end
+    end
+    -- 4. real global table: MarketDynamics publishes here from BUILD 11:43.
+    local okEnv, root = pcall(getfenv, 0)
+    if okEnv and type(root) == "table" and root[name] ~= nil then
+        return root[name]
+    end
+    -- 5. mission handle, same publish.
+    if g_currentMission ~= nil and g_currentMission[name] ~= nil then
+        return g_currentMission[name]
+    end
+    return nil
+end
+
 local function tr(key, fallback)
     local function tryI18n(i18n)
         if i18n == nil then
@@ -258,6 +314,7 @@ function RfPdaMenuPage.new()
     self.wcSubPageIndex = 1
     self.wcAboutTabIndex = 1
     self.mdSubPageIndex = 1
+    self.csSubPageIndex = 1
     self.mdCommodityData = {}
     self.mdSelectedFillType = nil
     self._panelCache = {}
@@ -269,6 +326,8 @@ function RfPdaMenuPage.new()
     self._wcSubnavSeeded = false
     self._mdSubnavSeeding = false
     self._mdSubnavSeeded = false
+    self._csSubnavSeeding = false
+    self._csSubnavSeeded = false
     self._lastModuleSelectId = nil
     self._lastModuleSelectAt = 0
     self._frameDebug = false
@@ -332,6 +391,14 @@ function RfPdaMenuPage:onGuiSetupFinished()
     self.csFieldsEmptyHint = self:getDescendantById("csFieldsEmptyHint") or self.csFieldsEmptyHint
     self.rfHostTableRegion = self:getDescendantById("rfHostTableRegion") or self.rfHostTableRegion
     self.csDetailStrip = self:getDescendantById("csDetailStrip") or self.csDetailStrip
+    self.csActionBar = self:getDescendantById("csActionBar") or self.csActionBar
+    self.csBtnConsultant = self:getDescendantById("csBtnConsultant") or self.csBtnConsultant
+    self.csBtnSchedule = self:getDescendantById("csBtnSchedule") or self.csBtnSchedule
+    self.csDetailNoCoverage = self:getDescendantById("csDetailNoCoverage") or self.csDetailNoCoverage
+    self.csConsultPanel = self:getDescendantById("csConsultPanel") or self.csConsultPanel
+    self.csPivotCard = self:getDescendantById("csPivotCard") or self.csPivotCard
+    self.csAgronomistCard = self:getDescendantById("csAgronomistCard") or self.csAgronomistCard
+    self.csFieldDetailCard = self:getDescendantById("csFieldDetailCard") or self.csFieldDetailCard
     self.mdGraphRegion = self:getDescendantById("mdGraphRegion") or self.mdGraphRegion
     self.mdGraphArea = self:getDescendantById("mdGraphArea") or self.mdGraphArea
     self.mdDetailStrip = self:getDescendantById("mdDetailStrip") or self.mdDetailStrip
@@ -346,6 +413,9 @@ function RfPdaMenuPage:onGuiSetupFinished()
     self.mdSubnavShell = self:getDescendantById("mdSubnavShell") or self.mdSubnavShell
     self.mdSubnavSelector = self:getDescendantById("mdSubnavSelector") or self.mdSubnavSelector
     self.mdSubnavDotBox = self:getDescendantById("mdSubnavDotBox") or self.mdSubnavDotBox
+    self.csSubnavShell = self:getDescendantById("csSubnavShell") or self.csSubnavShell
+    self.csSubnavSelector = self:getDescendantById("csSubnavSelector") or self.csSubnavSelector
+    self.csSubnavDotBox = self:getDescendantById("csSubnavDotBox") or self.csSubnavDotBox
     self.mdSideInfoShell = self:getDescendantById("mdSideInfoShell") or self.mdSideInfoShell
     self.mdSideInfoBody = self:getDescendantById("mdSideInfoBody") or self.mdSideInfoBody
     self.wcGlanceShell = self:getDescendantById("wcGlanceShell") or self.wcGlanceShell
@@ -365,6 +435,8 @@ function RfPdaMenuPage:onGuiSetupFinished()
     self.wcSideVersion = self:getDescendantById("wcSideVersion") or self.wcSideVersion
     self.rfSideInfoShell = self:getDescendantById("rfSideInfoShell") or self.rfSideInfoShell
     self.rfSideInfoBody = self:getDescendantById("rfSideInfoBody") or self.rfSideInfoBody
+    self.csSideInfoShell = self:getDescendantById("csSideInfoShell") or self.csSideInfoShell
+    self.csSideInfoBody = self:getDescendantById("csSideInfoBody") or self.csSideInfoBody
     self.rfSideMidSeparator = self:getDescendantById("rfSideMidSeparator") or self.rfSideMidSeparator
     self.rfModuleListShell = self:getDescendantById("rfModuleListShell") or self.rfModuleListShell
     self.wcPageShell = self:getDescendantById("wcPageShell") or self.wcPageShell
@@ -381,6 +453,9 @@ function RfPdaMenuPage:onGuiSetupFinished()
     self.soilColArea = self:getDescendantById("soilColArea") or self.soilColArea
     self.soilColStatus = self:getDescendantById("soilColStatus") or self.soilColStatus
     self.soilColFert = self:getDescendantById("soilColFert") or self.soilColFert
+    self.soilColWeed = self:getDescendantById("soilColWeed") or self.soilColWeed
+    self.soilColPest = self:getDescendantById("soilColPest") or self.soilColPest
+    self.soilColDisease = self:getDescendantById("soilColDisease") or self.soilColDisease
     self.soilSectionTreatment = self:getDescendantById("soilSectionTreatment") or self.soilSectionTreatment
     self.soilTreatProducts = self:getDescendantById("soilTreatProducts") or self.soilTreatProducts
     -- Read-only rotation card (2026-08-07). Nil-safe: older door XML lacks these ids.
@@ -389,6 +464,19 @@ function RfPdaMenuPage:onGuiSetupFinished()
     self.soilRotationLast   = self:getDescendantById("soilRotationLast") or self.soilRotationLast
     self.soilRotationStatus = self:getDescendantById("soilRotationStatus") or self.soilRotationStatus
     self.soilRotationTip    = self:getDescendantById("soilRotationTip") or self.soilRotationTip
+    -- What-if block (2026-08-08). Nil-safe: older door XML lacks these ids.
+    self.soilRotationWhatIfHeader = self:getDescendantById("soilRotationWhatIfHeader") or self.soilRotationWhatIfHeader
+    self.soilRotationIfColCrop    = self:getDescendantById("soilRotationIfColCrop") or self.soilRotationIfColCrop
+    self.soilRotationIfColStatus  = self:getDescendantById("soilRotationIfColStatus") or self.soilRotationIfColStatus
+    self.soilRotationIfColEffect  = self:getDescendantById("soilRotationIfColEffect") or self.soilRotationIfColEffect
+    self.soilRotationIfRows = {}
+    for i = 1, 3 do
+        self.soilRotationIfRows[i] = {
+            crop   = self:getDescendantById(string.format("soilRotationIf%dCrop", i)),
+            status = self:getDescendantById(string.format("soilRotationIf%dStatus", i)),
+            effect = self:getDescendantById(string.format("soilRotationIf%dEffect", i)),
+        }
+    end
     self.treatSelectedLabel = self:getDescendantById("treatSelectedLabel") or self.treatSelectedLabel
     self.treatNextLabel     = self:getDescendantById("treatNextLabel") or self.treatNextLabel
     self.treatTargetsLabel  = self:getDescendantById("treatTargetsLabel") or self.treatTargetsLabel
@@ -396,6 +484,7 @@ function RfPdaMenuPage:onGuiSetupFinished()
     self.treatTargetN       = self:getDescendantById("treatTargetN") or self.treatTargetN
     self.treatTargetP       = self:getDescendantById("treatTargetP") or self.treatTargetP
     self.treatTargetK       = self:getDescendantById("treatTargetK") or self.treatTargetK
+    self.treatTargetPH      = self:getDescendantById("treatTargetPH") or self.treatTargetPH
     self.treatPlanLines     = self:getDescendantById("treatPlanLines") or self.treatPlanLines
     self.treatProdRows = {}
     for i = 1, 8 do
@@ -444,7 +533,10 @@ function RfPdaMenuPage:_applyChromeL10n()
     setEl(self.soilColField, "sf_pda_col_field", "Field")
     setEl(self.soilColArea, "rf_pda_col_area", "Area")
     setEl(self.soilColStatus, "sf_pda_col_status", "Status")
-    setEl(self.soilColFert, "rf_pda_col_fert", "Fertilizer")
+    setEl(self.soilColFert, "rf_pda_col_fert", "FERT")
+    setEl(self.soilColWeed, "sf_pda_col_weeds", "Weeds")
+    setEl(self.soilColPest, "sf_pda_col_pests", "Pests")
+    setEl(self.soilColDisease, "sf_pda_col_disease", "Disease")
     setEl(self.fieldsEmptyHint, "sf_pda_no_fields", "No field data recorded yet.")
     setEl(self.soilSectionTreatment, "rf_pda_section_treatment", "Treatment")
     setEl(self.soilTreatProducts, "rf_pda_treat_products", "Products")
@@ -521,27 +613,22 @@ function RfPdaMenuPage:initialize()
                 mod.onOpenFullMarket()
                 return
             end
-            if MdRfPdaGuest ~= nil and type(MdRfPdaGuest.onOpenFullMarket) == "function" then
-                print("[MarketDynamics] Open full Market via in-env MdRfPdaGuest")
-                MdRfPdaGuest.onOpenFullMarket()
-                return
-            end
-            local mdEnv = g_modEnvironments ~= nil and g_modEnvironments["FS25_MarketDynamics"] or nil
-            local guest = mdEnv ~= nil and mdEnv.MdRfPdaGuest or nil
+            -- BUILD 12:59: this had its own two-belt resolve (in-env, then the hardcoded
+            -- MarketDynamics env key) and neither of the belts that actually work - the
+            -- getfenv/mission publish. Routed through mdResolve so SPACE and the footer
+            -- button share one implementation and one set of five belts.
+            local guest = (type(mdResolve) == "function")
+                    and mdResolve(MdRfPdaGuest, "MdRfPdaGuest") or MdRfPdaGuest
             if guest ~= nil and type(guest.onOpenFullMarket) == "function" then
-                print("[MarketDynamics] Open full Market via g_modEnvironments MdRfPdaGuest")
-                guest.onOpenFullMarket()
+                print("[MarketDynamics] Open full Market via resolved MdRfPdaGuest")
+                pcall(guest.onOpenFullMarket)
                 return
             end
-            local scr = mdEnv ~= nil and mdEnv.MDMMarketScreen or nil
+            local scr = (type(mdResolve) == "function")
+                    and mdResolve(MDMMarketScreen, "MDMMarketScreen") or MDMMarketScreen
             if scr ~= nil and type(scr.show) == "function" then
-                print("[MarketDynamics] Open full Market via g_modEnvironments MDMMarketScreen")
-                scr.show()
-                return
-            end
-            if MDMMarketScreen ~= nil and type(MDMMarketScreen.show) == "function" then
-                print("[MarketDynamics] Open full Market via in-env MDMMarketScreen")
-                MDMMarketScreen.show()
+                print("[MarketDynamics] Open full Market via resolved MDMMarketScreen")
+                pcall(scr.show)
                 return
             end
             print("[MarketDynamics] Open full Market: no handler available (all resolve paths nil)")
@@ -567,6 +654,16 @@ function RfPdaMenuPage:initialize()
             if wcGui ~= nil then
                 g_gui:showGui("WCGui")
             end
+        end
+    }
+    -- SPACE (MENU_EXTRA_1): Crop Stress consultant is secondary only — never default home.
+    -- EXTRA_1 free on CS (Help is Soil-only). SmoothList would swallow MENU_ACTIVATE.
+    self.btnCsConsultant = {
+        inputAction = InputAction.MENU_EXTRA_1,
+        showWhenPaused = true,
+        text = tr("cs_rf_pda_btn_consultant", "Crop consultant"),
+        callback = function()
+            self:onClickCsConsultant()
         end
     }
 
@@ -596,11 +693,20 @@ end
 
 function RfPdaMenuPage:onFrameOpen()
     RfPdaMenuPage:superClass().onFrameOpen(self)
-    self.isOpen = true
     self._liveTimer = 0
     self._rfSoilPanelMissingWarned = false
     self:_bindHostListener()
     self:_applyChromeL10n()
+    -- Module home BEFORE isOpen so select/notify cannot dual-fire refresh + onShow.
+    do
+        local host = self:_getHost()
+        if host ~= nil and type(host.applyHomeModuleQuiet) == "function" then
+            pcall(function()
+                host:applyHomeModuleQuiet()
+            end)
+        end
+    end
+    self.isOpen = true
     -- F11: lime arrows before and after first refresh (engine may disable on open).
     self:_ensureSelectorArrowsVisible()
     self:refreshPanelSelector(true)
@@ -609,6 +715,19 @@ function RfPdaMenuPage:onFrameOpen()
 end
 
 function RfPdaMenuPage:onFrameClose()
+    do
+        local host = self:_getHost()
+        if host ~= nil and host.activeModuleId ~= nil then
+            if type(host.rememberClosedModule) == "function" then
+                pcall(function()
+                    host:rememberClosedModule(host.activeModuleId)
+                end)
+            else
+                host._lastClosedModuleId = host.activeModuleId
+                host._userHasChosenModule = true
+            end
+        end
+    end
     self.isOpen = false
     RfPdaMenuPage:superClass().onFrameClose(self)
 end
@@ -641,18 +760,150 @@ function RfPdaMenuPage:draw(clipX1, clipY1, clipX2, clipY2)
         local host = self:_getHost()
         local active = host and host.getActivePanel and host:getActivePanel()
         local pageIdx = tonumber(self.mdSubPageIndex) or 1
-        if active ~= nil and active.id == "marketDynamics"
-                and pageIdx == 1
+        local graph = (type(mdResolve) == "function")
+                and mdResolve(MDMMarketScreenGraph, "MDMMarketScreenGraph") or MDMMarketScreenGraph
+        local mdGuest = (type(mdResolve) == "function")
+                and mdResolve(MdRfPdaGuest, "MdRfPdaGuest") or MdRfPdaGuest
+        -- BUILD 00:10: the outer skip log fires BEFORE any gate. The 22:27 log lived
+        -- inside the abs gate, so the one case worth seeing - the gate refusing - printed
+        -- nothing at all. Same failure shape as the bug it was meant to diagnose.
+        local isMdPrices = active ~= nil and active.id == "marketDynamics" and pageIdx == 1
+        if isMdPrices and not self._mdGraphOuterLogged then
+            self._mdGraphOuterLogged = true
+            local a = self.mdGraphArea
+            local b = self.mdPricesBand
+            local function box(el)
+                if el == nil then return "nil-element" end
+                if el.absSize == nil or el.absPosition == nil then return "no-abs" end
+                return string.format("%.4fx%.4f at %.4f,%.4f",
+                    el.absSize[1] or -1, el.absSize[2] or -1,
+                    el.absPosition[1] or -1, el.absPosition[2] or -1)
+            end
+            local before = box(a)
+            if a ~= nil and type(a.updateAbsolutePosition) == "function" then
+                pcall(function() a:updateAbsolutePosition() end)
+            end
+            -- Name the belt that won, so a nil class is immediately attributable rather
+            -- than another round of narrowing.
+            local via = "nil"
+            if graph ~= nil then
+                if MDMMarketScreenGraph ~= nil then
+                    via = "in-env"
+                elseif g_modEnvironments ~= nil and g_modEnvironments["FS25_MarketDynamics"] ~= nil
+                        and g_modEnvironments["FS25_MarketDynamics"].MDMMarketScreenGraph ~= nil then
+                    via = "modEnv-named"
+                else
+                    local okE, rootE = pcall(getfenv, 0)
+                    if okE and type(rootE) == "table" and rootE.MDMMarketScreenGraph ~= nil then
+                        via = "getfenv0"
+                    elseif g_currentMission ~= nil and g_currentMission.MDMMarketScreenGraph ~= nil then
+                        via = "mission"
+                    else
+                        via = "modEnv-scan"
+                    end
+                end
+            end
+            print(string.format(
+                "[MarketDynamics] Esc graph GATE: band=%s area=%s graph=%s via=%s trend=%s draw=%s | area before=%s after=%s | band=%s",
+                tostring(b ~= nil), tostring(a ~= nil), tostring(graph ~= nil), via,
+                tostring(graph ~= nil and type(graph.drawPriceTrend) == "function"),
+                tostring(graph ~= nil and type(graph.draw) == "function"),
+                before, box(a), box(b)))
+        end
+
+        -- BUILD 11:43: accept either entry point, prefer the shared tree. Gating on
+        -- graph.draw alone would refuse a companion that has drawPriceTrend, and the
+        -- shared tree is the one both surfaces are supposed to be using.
+        local hasTrend = graph ~= nil and type(graph.drawPriceTrend) == "function"
+        local hasDraw = graph ~= nil and type(graph.draw) == "function"
+        if isMdPrices
                 and self.mdPricesBand ~= nil
-                and MDMMarketScreenGraph ~= nil and type(MDMMarketScreenGraph.draw) == "function" then
+                and (hasTrend or hasDraw) then
             local area = self.mdGraphArea
-            if area ~= nil and area.absPosition ~= nil and area.absSize ~= nil then
+            -- Abs-size guard: on the first frame after the band becomes visible the area
+            -- can still carry a stale or zero size, which would draw into a degenerate rect.
+            if area ~= nil and (area.absSize == nil or area.absPosition == nil
+                    or (area.absSize[1] or 0) <= 0 or (area.absSize[2] or 0) <= 0) then
+                if type(area.updateAbsolutePosition) == "function" then
+                    pcall(function() area:updateAbsolutePosition() end)
+                end
+            end
+
+            -- BUILD 00:10: if the area is STILL unusable, do not give up silently. Derive a
+            -- rect from mdPricesBand and feed the SAME drawPriceTrend. My 21:41 guard failed
+            -- closed, which turned a layout-timing problem into a permanently blank panel.
+            -- A plot in a slightly generous box is a better answer than no plot, and it is
+            -- still the one shared decision tree - no Esc fork, nothing invented.
+            local useBand = false
+            if area == nil or area.absPosition == nil or area.absSize == nil
+                    or (area.absSize[1] or 0) <= 0 or (area.absSize[2] or 0) <= 0 then
+                local b = self.mdPricesBand
+                if b ~= nil and b.absPosition ~= nil and b.absSize ~= nil
+                        and (b.absSize[1] or 0) > 0 and (b.absSize[2] or 0) > 0 then
+                    useBand = true
+                    if not self._mdGraphBandFallbackLogged then
+                        self._mdGraphBandFallbackLogged = true
+                        print(string.format(
+                            "[MarketDynamics] Esc graph: mdGraphArea unusable, drawing into mdPricesBand rect %.4fx%.4f",
+                            b.absSize[1], b.absSize[2]))
+                    end
+                end
+            end
+
+            if useBand or (area ~= nil and area.absPosition ~= nil and area.absSize ~= nil
+                    and (area.absSize[1] or 0) > 0 and (area.absSize[2] or 0) > 0) then
+                -- Resolve the fill type from the host first, then the guest. Both are asked
+                -- because the host copy is set on full show and the guest owns the live pick.
                 local ft = self.mdSelectedFillType
-                if ft == nil and MdRfPdaGuest ~= nil and type(MdRfPdaGuest.getSelectedFillType) == "function" then
-                    ft = MdRfPdaGuest.getSelectedFillType()
+                if ft == nil and mdGuest ~= nil and type(mdGuest.getSelectedFillType) == "function" then
+                    local okFt, v = pcall(mdGuest.getSelectedFillType)
+                    ft = okFt and v or nil
+                end
+                -- BUILD 23:43: pre-ft skip log. Everything below needs ft, so a nil here is a
+                -- silent no-draw; say so once instead of leaving a blank panel unexplained.
+                if ft == nil and not self._mdGraphFtLogged then
+                    self._mdGraphFtLogged = true
+                    print(string.format(
+                        "[MarketDynamics] Esc graph SKIP: no fill type resolved (host=%s guest=%s useBand=%s)",
+                        tostring(self.mdSelectedFillType), tostring(mdGuest ~= nil), tostring(useBand)))
                 end
                 if ft ~= nil then
-                    MDMMarketScreenGraph.draw(ft, area.absPosition[1], area.absPosition[2], area.absSize[1], area.absSize[2])
+                    local src = useBand and self.mdPricesBand or area
+                    local gx = src.absPosition[1]
+                    local gy = src.absPosition[2]
+                    local gw = src.absSize[1]
+                    local gh = src.absSize[2]
+                    if useBand then
+                        -- Inset the band a little so the plot does not run into its edges.
+                        gx = gx + gw * 0.04
+                        gy = gy + gh * 0.10
+                        gw = gw * 0.92
+                        gh = gh * 0.62
+                    end
+                    local sampleCount = 0
+                    if type(graph.getSampleCount) == "function" then
+                        sampleCount = graph.getSampleCount(ft) or 0
+                    end
+                    -- BUILD 23:43: the Esc fork is gone. One shared decision tree lives in
+                    -- MDMMarketScreenGraph.drawPriceTrend and the full Market screen calls the
+                    -- same one, so the two surfaces cannot disagree about the same crop again.
+                    -- The old fork here had no global-sample step and no aggregated-median
+                    -- branch, which is why Esc could be blank while Market plotted.
+                    local branch = "thin"
+                    if type(graph.drawPriceTrend) == "function" then
+                        local okB, b = pcall(graph.drawPriceTrend, ft, gx, gy, gw, gh)
+                        branch = (okB and b) or "thin"
+                    elseif sampleCount >= 2 then
+                        -- Companion older than this build: keep the plot rather than blank it.
+                        graph.draw(ft, gx, gy, gw, gh)
+                        branch = "ring"
+                    end
+                    if not self._mdGraphLogged then
+                        self._mdGraphLogged = true
+                        print(string.format(
+                            "[MarketDynamics] Esc graph: box=%.1fx%.1f at %.3f,%.3f ft=%s samples=%d branch=%s",
+                            gw or -1, gh or -1, gx or -1, gy or -1, tostring(ft), sampleCount, tostring(branch)))
+                    end
                 end
             end
         end
@@ -689,18 +940,45 @@ function RfPdaMenuPage:update(dt)
     -- Market Dynamics: light text/graph refresh; never SmoothList thrash.
     if isMd then
         local pageIdx = tonumber(self.mdSubPageIndex) or 1
-        if pageIdx == 1 and MDMMarketScreenGraph ~= nil and type(MDMMarketScreenGraph.update) == "function" then
-            pcall(MDMMarketScreenGraph.update, dt)
+        -- BUILD 21:41: same cross-env resolve as draw. This is the sample ring tick, so
+        -- leaving it bare would have kept getSampleCount at 0 under a foreign host even
+        -- with the draw fixed, and the graph would have limped on engine history alone.
+        local graphUpd = (type(mdResolve) == "function")
+                and mdResolve(MDMMarketScreenGraph, "MDMMarketScreenGraph") or MDMMarketScreenGraph
+        if pageIdx == 1 and graphUpd ~= nil and type(graphUpd.update) == "function" then
+            pcall(graphUpd.update, dt)
         end
         self._mdLiveTimer = (self._mdLiveTimer or 0) + dt
         if self._mdLiveTimer >= REFRESH_INTERVAL then
             self._mdLiveTimer = 0
-            if active ~= nil and type(active.onShow) == "function" then
+            -- BUILD 22:27: was a full onShow(.., true) every 2000ms, which ran three
+            -- updateAbsolutePosition calls, re-seeded the subnav, re-synced visibility and
+            -- re-asserted the selection. Re-laying out the table twice a second is what
+            -- kept nudging the scroll. The guest light tick repaints digits only.
+            local mdGuest = (type(mdResolve) == "function")
+                    and mdResolve(MdRfPdaGuest, "MdRfPdaGuest") or MdRfPdaGuest
+            -- Prefer the registered handler; the direct guest is the belt if it was dropped.
+            local light = (active ~= nil and type(active.onLightTick) == "function")
+                    and active.onLightTick
+                    or (mdGuest ~= nil and mdGuest.onLightTick or nil)
+            if type(light) == "function" then
+                pcall(light, self.rfHostPlaceholder)
+            elseif active ~= nil and type(active.onShow) == "function" then
+                -- Older MarketDynamics without onLightTick: keep the previous behaviour
+                -- rather than silently stop refreshing prices.
                 pcall(active.onShow, self.rfHostPlaceholder, true)
             end
         end
         return
     end
+
+    -- One-shot graph log re-arms whenever Market Dynamics is not the active module, so
+    -- each visit to Prices reports once instead of once per session.
+    self._mdGraphLogged = false
+    self._mdGraphFtLogged = false
+    self._mdGraphOuterLogged = false
+    self._mdGraphBandFallbackLogged = false
+    self._mdGuestBeltLogged = false
 
     -- WC Dashboard/Workers: 500ms text-only live refresh (George FULL PORT ACK).
     if isWc then
@@ -1120,17 +1398,29 @@ function RfPdaMenuPage:_refreshSideInfo(activeId)
             el:setVisible(visible)
         end
     end
+    -- BUILD 21:06: CS is back in the Soil-class shell. The 16:44 nest existed only
+    -- because the teach painted over FIELDS and the page dots; the subnav that owned
+    -- those is retired, so the thing it was avoiding no longer exists. csSideInfoShell
+    -- is forced hidden rather than deleted, so a stale nested copy can never surface.
     setVis(self.rfSideInfoShell, isSoil or isCs or isFw)
+    setVis(self.csSideInfoShell, false)
     setVis(self.wcSideInfoShell, isWc)
     setVis(self.mdSideInfoShell, isMd)
     setVis(self.rfSuiteHint, false)
+    -- BUILD 16:44 item 5: CS teach paints into the nested body under the subnav.
+    -- The filter-box body is cleared for CS so a stale sentence cannot survive
+    -- behind the new shell if visibility ever flips back.
+    -- Nested body is cleared unconditionally now, not just for non-CS.
+    if self.csSideInfoBody ~= nil and self.csSideInfoBody.setText then
+        self.csSideInfoBody:setText("")
+    end
     if self.rfSideInfoBody and self.rfSideInfoBody.setText then
         if isSoil then
             self.rfSideInfoBody:setText(tr("rf_pda_side_info_soil",
-                "Soil Fertilizer\n\nThis table lists every field you own. One row = one field.\n\nColumns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).\n\nClick a row. Treatment (below) is the plan for that field:\n- PRODUCT = what to buy (first is preferred; \"or ...\" is an alternate)\n- RATE = amount per area / TOTAL = amount for this field\n- Selected names the field; Next (under it) says what to do first\n\nHow to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.\n\nStart with the weakest Status, open Treatment, follow Next, then the rest of the list."))
+                "Soil Fertilizer\n\nThis screen shows the soil on your owned fields. Each line is one field. Press X HELP for the full Field Guide.\n\nThe table shows Field, Area, N, P, K, pH, Status, FERT, Weeds, Pests, and Disease. Status is Good, Fair, or Poor from the worst nutrient or pressure. Work the weakest Status first. When FERT says IN NEED, that field needs fertilizer.\n\nClick a field to open Treatment. PRODUCTS lists what to use, top first. RATE is per area. TOTAL is for the whole field. Next is the first job. Target is healthy. Fix lime or gypsum before nutrients. Dry goes in a spreader. Liquid goes in a sprayer. High Weeds, Pests, or Disease means spray first.\n\nWhat-if lets you try the next crop. Field plan and rotation are on the cards. N falls every harvest. P and K move slower. Organic matter builds over seasons. Aim for pH 6.5 to 7.0. Check worst fields, treat top-down, recheck.\n\nLime raises acid soil. Gypsum lowers alkaline soil. Use N often. Use P and K every few seasons. Press X HELP for lists, HUD tips, and FAQ."))
         elseif isCs then
             self.rfSideInfoBody:setText(tr("rf_pda_side_info_crop_stress",
-                "Crop Stress\n\nThis table lists every field you own. One row = one field.\n\nColumns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).\n\nClick a row. The strip below names the field, then Next says what to do first:\n- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)\n- High Stress or a sensitive growth window → protect now; stress today cuts harvest later\n- Looking fine → recheck later; worse fields first\n\nIrrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.\n\nIf Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.\n\nStart with Critical Status, follow Next, then work up the list."))
+                "Crop Stress\n\nThis screen is the Crop Stress desk. Each line is one field you own.\n\nThe table shows Field, Crop, Moisture, Stress, Irrigated, and Status. Moisture is how wet the soil is. Stress is how hard the crop is fighting dry spells. Irrigated says a system can reach this field. Status is Healthy, Warning, or Critical.\n\nClick a row. Field Detail on the left coaches that field and Next says the first job. AGRONOMIST on the right lists the top risk fields. PIVOT below drives the irrigation system for the selected field.\n\nOn PIVOT, grey remotes are locked until the step before them is done. Open the door, then power, then the rest. An empty seat means no pivot covers this field.\n\nStart with Critical Status, follow Next, then work up the list.\n\nIrrigator kit (shop): pump + Rainstar + pull bar. Unfold, pull the gun out, turn it on over a field."))
         else
             self.rfSideInfoBody:setText("")
         end
@@ -1154,6 +1444,27 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
         end
     end
     setVis(self.rfHostTableRegion, isCs)
+    -- Action bar rides the CS module only; the guest decides the two buttons.
+    setVis(self.csActionBar, isCs)
+    if not isCs then
+        setVis(self.csBtnSchedule, false)
+        setVis(self.csDetailNoCoverage, false)
+        setVis(self.csConsultPanel, false)
+        setVis(self.csPivotCard, false)
+        setVis(self.csAgronomistCard, false)
+        self._csConsultOpen = false
+    else
+        -- BUILD 18:48: the table-hiding consultant view is dead (George HARD VETO).
+        -- csConsultPanel is never shown again; the agronomist content moved into the
+        -- ROTATION-seat card, and the field table stays visible on every CS subpage.
+        -- rfHostTableRegion is still gated above by module id only, which is the gate
+        -- George kept; what is banned is the intra-CS swap that emptied the table slot.
+        setVis(self.csConsultPanel, false)
+        self._csConsultOpen = false
+        -- BUILD 21:06: no subnav seeding. _syncCsSubPageVisibility stays because it is
+        -- what makes AGRONOMIST and PIVOT co-visible; it never gated on the index.
+        self:_syncCsSubPageVisibility()
+    end
     setVis(self.csFieldOverviewList, isCs)
     setVis(self.csDetailStrip, isCs)
     -- MDM three-page chrome (TOP table + BOTTOM bands + secondary subnav).
@@ -1236,6 +1547,42 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
             self._mdSubnavSeeded = false
         end
     end
+    -- BUILD 21:06: CS subnav RETIRED. Crop Stress is one desk - table, Field Detail,
+    -- AGRONOMIST and PIVOT are co-visible - so a Fields | Pivot selector selects nothing.
+    -- Never setVisible(true) for CS. WC and MDM subnavs are untouched.
+    setVis(self.csSubnavShell, false)
+    setVis(self.csSubnavSelector, false)
+    setVis(self.csSubnavDotBox, false)
+    if self.csSubnavSelector ~= nil then
+        if false then
+            self.csSubnavSelector.disableButtonsOnSingleText = false
+            self.csSubnavSelector.hideLeftRightButtons = false
+            if type(self.csSubnavSelector.setDisabled) == "function" then
+                self.csSubnavSelector:setDisabled(false)
+            end
+            if type(self.csSubnavSelector.setCanChangeState) == "function" then
+                self.csSubnavSelector:setCanChangeState(true)
+            end
+            if self.csSubnavShell ~= nil and type(self.csSubnavShell.updateAbsolutePosition) == "function" then
+                self.csSubnavShell:updateAbsolutePosition()
+            end
+            if type(self.csSubnavSelector.updateAbsolutePosition) == "function" then
+                self.csSubnavSelector:updateAbsolutePosition()
+            end
+            if type(self._ensureCsSubnavArrowsVisible) == "function" then
+                self:_ensureCsSubnavArrowsVisible()
+            end
+        else
+            self.csSubnavSelector.hideLeftRightButtons = true
+            if type(self.csSubnavSelector.setDisabled) == "function" then
+                self.csSubnavSelector:setDisabled(true)
+            end
+            if type(self.csSubnavSelector.setCanChangeState) == "function" then
+                self.csSubnavSelector:setCanChangeState(false)
+            end
+            self._csSubnavSeeded = false
+        end
+    end
     if self.wcSubnavSelector ~= nil then
         if isWc then
             self.wcSubnavSelector.disableButtonsOnSingleText = false
@@ -1283,7 +1630,12 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     setVis(self.wcSideVersion, false)
     setVis(self.mdSideInfoShell, isMd)
     -- Keep framework (Income/Depot/etc) side shell; dots always visible per origin/development tip.
+    -- BUILD 21:06b (Ash note): this pair used to disagree with _refreshSideInfo below, which
+    -- then corrected it 30 lines later. Harmless today - I checked, there is no early return
+    -- between here and that call - but two sites stating opposite truths about the same two
+    -- elements is a trap waiting for the first person to add one. They agree now.
     setVis(self.rfSideInfoShell, isSoil or isCs or isFw)
+    setVis(self.csSideInfoShell, false)
     -- Module page dots always visible (umbrella: dots = N, chrome geometry unchanged).
     setVis(self.rfPanelDotBox, true)
     setVis(self.rfDotLegend, false)
@@ -1331,8 +1683,16 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
         end
     elseif isWc and self.btnOpenWorkerManager ~= nil then
         self.menuButtonInfo = { self.btnBack, self.btnOpenWorkerManager }
+    elseif isCs then
+        -- BUILD 18:48: SPACE no longer swaps panes. The consultant button owned the
+        -- table-hiding path, so it comes off the CS footer entirely rather than being
+        -- left pointing at a no-op the player can still press.
+        self.menuButtonInfo = { self.btnBack }
     elseif isSoil then
-        self.menuButtonInfo = { self.btnBack, self.btnHelp, self.btnRotationPlanner, self.btnFieldDetail }
+        -- BUILD 18:52: Rotation Planner and Field Detail come off the Soil footer.
+        -- Both dialogs stay registered and still open from the PDA/joiner; only the
+        -- duplicate bottom-bar buttons go, since the cards now carry that content.
+        self.menuButtonInfo = { self.btnBack, self.btnHelp }
     else
         self.menuButtonInfo = { self.btnBack }
     end
@@ -1822,6 +2182,246 @@ function RfPdaMenuPage:onClickWcWageReset()
     end
 end
 
+
+--- Esc Crop Stress actions. The host never speaks CsDialogLoader (SCS-env-scoped,
+--- George binding); it delegates to the active guest, which routes through the
+--- CropStress manager. Same shape as onClickWcWageReset.
+--- Toggle the inline consultant readout against the field table. Exactly one of
+--- {csConsultPanel, rfHostTableRegion} is visible; the host never unloads either,
+--- it only flips setVisible, so no list rebuild and no reloadData thrash.
+--- Closing consultant restores the same field-row selection (SoT) + PIVOT card.
+--- BUILD 18:48: dead by design, kept callable.
+--- George HARD VETO on any path that hides rfHostTableRegion to paint consultant
+--- content in the main pane. This used to be that path. It is not deleted because
+--- the SCS guest still calls it on show and wraps it, and a nil call there would
+--- take the whole Crop Stress paint down with it. It now always leaves the field
+--- table visible and the old consult panel hidden, whatever it is passed.
+function RfPdaMenuPage:setCsConsultView(_open)
+    self._csConsultOpen = false
+    if self.csConsultPanel ~= nil and self.csConsultPanel.setVisible then
+        self.csConsultPanel:setVisible(false)
+    end
+    if self.rfHostTableRegion ~= nil and self.rfHostTableRegion.setVisible then
+        self.rfHostTableRegion:setVisible(true)
+    end
+    self:_syncCsSubPageVisibility()
+end
+
+--- Kept so any stale binding resolves to something inert rather than erroring.
+function RfPdaMenuPage:onClickCsConsultant()
+    return
+end
+
+function RfPdaMenuPage:_csPageSel()
+    return self.csSubnavSelector
+end
+
+function RfPdaMenuPage:_ensureCsSubnavArrowsVisible()
+    self:_ensureMtoArrowsVisible(self:_csPageSel())
+end
+
+--- RETIRED BUILD 21:06. Kept as a no-op because callers may still reference it and
+--- because its body called sel:setVisible(true) itself - leaving it live would have
+--- re-shown the selector from behind the visibility gate above.
+function RfPdaMenuPage:_seedCsSubnavTexts()
+    do return end
+    local sel = self:_csPageSel()
+    if sel == nil then
+        return
+    end
+    if self._csSubnavSeeded then
+        return
+    end
+    local trFn = self._rfTr
+    local function t(key, fb)
+        if type(trFn) == "function" then
+            return trFn(key, fb)
+        end
+        return fb
+    end
+    if sel.setVisible then
+        sel:setVisible(true)
+    end
+    sel.disableButtonsOnSingleText = false
+    sel.hideLeftRightButtons = false
+    if sel.setCanChangeState then
+        sel:setCanChangeState(true)
+    end
+    if sel.setDisabled then
+        sel:setDisabled(false)
+    end
+    local texts = {
+        t("cs_rf_pda_page_fields", "Fields"),
+        t("cs_rf_pda_page_pivot", "Pivot"),
+    }
+    self._csSubnavSeeding = true
+    if sel.setTexts then
+        sel:setTexts(texts)
+    end
+    local idx = tonumber(self.csSubPageIndex) or 1
+    if idx < 1 then idx = 1 end
+    if idx > 2 then idx = 2 end
+    self.csSubPageIndex = idx
+    if sel.setState then
+        sel:setState(idx, false)
+    end
+    self._csSubnavSeeding = false
+    self._csSubnavSeeded = true
+    self:_ensureCsSubnavArrowsVisible()
+    self:_rebuildCsSubnavDots(2)
+    if self.csSubnavShell ~= nil and self.csSubnavShell.updateAbsolutePosition then
+        self.csSubnavShell:updateAbsolutePosition()
+    end
+    if sel.updateAbsolutePosition then
+        sel:updateAbsolutePosition()
+    end
+end
+
+function RfPdaMenuPage:_rebuildCsSubnavDots(count)
+    local dotBox = self.csSubnavDotBox
+    if dotBox == nil or dotBox.elements == nil or #dotBox.elements == 0 then
+        return
+    end
+    if type(dotBox.setVisible) == "function" then
+        dotBox:setVisible(true)
+    end
+    local elements = dotBox.elements
+    local expectedCount = math.max(1, count or 1)
+    while #elements < expectedCount do
+        local seed = elements[1]
+        if seed == nil or seed.clone == nil then
+            break
+        end
+        local ok, clone = pcall(function()
+            return seed:clone(dotBox)
+        end)
+        if not ok or clone == nil then
+            break
+        end
+        if FocusManager and FocusManager.loadElementFromCustomValues then
+            pcall(FocusManager.loadElementFromCustomValues, FocusManager, clone)
+        end
+        elements = dotBox.elements
+    end
+    while #elements > expectedCount do
+        local last = elements[#elements]
+        if last ~= nil and last.delete then
+            last:delete()
+        end
+        elements = dotBox.elements
+    end
+    for i, dot in ipairs(dotBox.elements) do
+        local index = i
+        function dot.getIsSelected()
+            local sel = self:_csPageSel()
+            if sel == nil or sel.getState == nil then
+                return index == 1
+            end
+            return sel:getState() == index
+        end
+        if dot.setVisible then
+            dot:setVisible(true)
+        end
+    end
+    if dotBox.invalidateLayout then
+        dotBox:invalidateLayout()
+    end
+    if type(dotBox.updateAbsolutePosition) == "function" then
+        dotBox:updateAbsolutePosition()
+    end
+end
+
+--- Esc CS breath (2026-08-09): Agronomist (upper-right) + Pivot (lower-right) are
+--- both visible on the CS bottom band. Subnav may still track Fields|Pivot focus,
+--- but must not exclusive-hide either card. Table + detail strip stay up; never
+--- touch rfHostTableRegion here (table-hide consult remains VETO).
+function RfPdaMenuPage:_syncCsSubPageVisibility()
+    local idx = tonumber(self.csSubPageIndex) or 1
+    if idx < 1 then idx = 1 end
+    if idx > 2 then idx = 2 end
+    self.csSubPageIndex = idx
+    local function setVis(el, visible)
+        if el ~= nil and type(el.setVisible) == "function" then
+            el:setVisible(visible)
+        end
+    end
+    setVis(self.csAgronomistCard, true)
+    setVis(self.csPivotCard, true)
+end
+
+--- Sibling-shell CS page MTO. Page index only - never Brand / selectPanel.
+--- setState(idx, false): forceEvent re-entry is the WC arrow-crash shape.
+function RfPdaMenuPage:onClickCsSubnavSelector()
+    -- RETIRED BUILD 21:06: the selector is never visible, so this can only fire from a
+    -- stale binding. No-op rather than removed, so the XML onClick target still resolves.
+    do return end
+    if self._csSubnavSeeding then
+        return
+    end
+    local sel = self:_csPageSel()
+    if sel == nil or sel.getState == nil then
+        return
+    end
+    if sel ~= self.csSubnavSelector then
+        return
+    end
+    self:_ensureCsSubnavArrowsVisible()
+    local idx = sel:getState() or 1
+    if idx < 1 then idx = 1 end
+    if idx > 2 then idx = 2 end
+    self.csSubPageIndex = idx
+    if sel.setState and sel:getState() ~= idx then
+        sel:setState(idx, false)
+    end
+    self:_syncCsSubPageVisibility()
+    -- Light onShow only: a full seed here would rebuild the field SmoothList on
+    -- every page flick, which is the reload thrash the hang fences ban.
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active ~= nil and active.id == "seasonalCropStress" and type(active.onShow) == "function" then
+        pcall(active.onShow, self.rfHostPlaceholder, true)
+    end
+end
+
+function RfPdaMenuPage:onClickCsSchedule()
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active ~= nil and type(active.onOpenSchedule) == "function" then
+        pcall(active.onOpenSchedule, self.rfHostPlaceholder)
+    end
+end
+
+--- Esc PIVOT remote clicks → guest → CropStressPivotRemoteEvent (server authority).
+local function _csPivotRemote(self, action)
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active ~= nil and type(active.onPivotRemote) == "function" then
+        pcall(active.onPivotRemote, self.rfHostPlaceholder, action)
+    else
+        -- BUILD 12:59: resolved rather than bare, so the CS pivot fallback survives a
+        -- foreign door the same way the MDM paths do.
+        local csGuest = (type(mdResolve) == "function")
+                and mdResolve(CsRfPdaGuest, "CsRfPdaGuest") or CsRfPdaGuest
+        if csGuest ~= nil and type(csGuest.onPivotRemote) == "function" then
+            pcall(csGuest.onPivotRemote, self.rfHostPlaceholder, action)
+        end
+    end
+end
+
+function RfPdaMenuPage:onClickCsPivotDoor()    _csPivotRemote(self, "DOOR_TOGGLE") end
+function RfPdaMenuPage:onClickCsPivotPower()   _csPivotRemote(self, "POWER_TOGGLE") end
+function RfPdaMenuPage:onClickCsPivotSpray()   _csPivotRemote(self, "SPRAY_TOGGLE") end
+function RfPdaMenuPage:onClickCsPivotEndGun()  _csPivotRemote(self, "END_GUN_TOGGLE") end
+function RfPdaMenuPage:onClickCsPivotSpeed()   _csPivotRemote(self, "SPEED_CYCLE") end
+function RfPdaMenuPage:onClickCsPivotStart()   _csPivotRemote(self, "AUTO_START") end
+function RfPdaMenuPage:onClickCsPivotStop()    _csPivotRemote(self, "AUTO_STOP") end
+function RfPdaMenuPage:onClickCsPivotMinUp()   _csPivotRemote(self, "SWEEP_MIN_UP") end
+function RfPdaMenuPage:onClickCsPivotMinDn()   _csPivotRemote(self, "SWEEP_MIN_DN") end
+function RfPdaMenuPage:onClickCsPivotMaxUp()   _csPivotRemote(self, "SWEEP_MAX_UP") end
+function RfPdaMenuPage:onClickCsPivotMaxDn()   _csPivotRemote(self, "SWEEP_MAX_DN") end
+function RfPdaMenuPage:onClickCsPivotArmPlus() _csPivotRemote(self, "ARM_STEP_PLUS") end
+function RfPdaMenuPage:onClickCsPivotArmMinus() _csPivotRemote(self, "ARM_STEP_MINUS") end
+
 --- @param rebuildLists boolean|nil when true (default), rebuild field SmoothList data
 function RfPdaMenuPage:refreshContent(rebuildLists)
     if rebuildLists == nil then
@@ -1835,8 +2435,18 @@ function RfPdaMenuPage:refreshContent(rebuildLists)
     local prevId = self._lastShownPanelId
     local enteringSoil = isSoil and prevId ~= "soilFertilizer"
     local enteringCs = panelId == "seasonalCropStress" and prevId ~= "seasonalCropStress"
+    local enteringMd = panelId == "marketDynamics" and prevId ~= "marketDynamics"
     local doSoilListRebuild = rebuildLists or enteringSoil
     local doCsListRebuild = rebuildLists or enteringCs
+    local doMdListRebuild = rebuildLists or enteringMd
+
+    -- Crop Stress home = field table + AGRONOMIST card (Samantha DESIGN 18:48).
+    -- Entering CS always lands on subpage 1; PIVOT is never a sticky home.
+    if enteringCs then
+        self._csConsultOpen = false
+        self.csSubPageIndex = 1
+        self._csSubnavSeeded = false
+    end
 
     self:_refreshPageHeader(active)
     self:_applyChromeL10n()
@@ -1927,16 +2537,56 @@ function RfPdaMenuPage:refreshContent(rebuildLists)
                 self:_ensureWcWageArrowsVisible()
             end
         end
-        if active ~= nil and active.id == "marketDynamics" then
+        -- BUILD 23:43: subnav seed / visibility sync are enter-and-rebuild work. Running
+        -- them on every soft refresh was part of the same churn as the fat onShow.
+        if active ~= nil and active.id == "marketDynamics" and doMdListRebuild then
             self:_seedMdSubnavTexts()
             self:_syncMdSubPageVisibility()
             self:_ensureMdSubnavArrowsVisible()
             self:_ensureSelectorArrowsVisible()
+            -- BUILD 00:10: lay the graph box out on ENTER. draw() only ever retried it
+            -- mid-frame, so a band that had not been positioned yet gave a zero-size area
+            -- and the abs gate refused for as long as that lasted. Enter is a full show,
+            -- so this is the right place for it and it is not on any light path.
+            for _, id in ipairs({"mdPricesBand", "mdGraphArea"}) do
+                local el = self:getDescendantById(id)
+                if el ~= nil and type(el.updateAbsolutePosition) == "function" then
+                    pcall(function() el:updateAbsolutePosition() end)
+                end
+            end
         end
         if active ~= nil and type(active.onShow) == "function" then
             if active.id == "seasonalCropStress" then
                 -- Full CS field list reload only on enter / rebuildLists (lightOnly otherwise).
+                -- Guest onShow paints consultant when entering (default-home lock).
                 pcall(active.onShow, self.rfHostPlaceholder, not doCsListRebuild)
+            elseif active.id == "marketDynamics" then
+                -- BUILD 23:43: a soft refreshContent(false) now runs the guest LIGHT tick, not
+                -- a lightOnly onShow. lightOnly still re-laid out the table, band and graph and
+                -- re-asserted the selection, which is the scroll jump. Enter and explicit
+                -- rebuilds keep the full onShow(false).
+                if doMdListRebuild then
+                    pcall(active.onShow, self.rfHostPlaceholder, false)
+                else
+                    -- BUILD 23:51 belt: prefer the registered handler, but fall back to the
+                    -- guest directly if the registry dropped it. Vera found exactly that -
+                    -- active.onLightTick was nil, so the soft path took the fat onShow and
+                    -- 23:43 changed nothing where it counted. Never the fat onShow while a
+                    -- light tick exists anywhere we can reach it.
+                    local light = active.onLightTick
+                    if type(light) ~= "function" then
+                        local lg = (type(mdResolve) == "function")
+                                and mdResolve(MdRfPdaGuest, "MdRfPdaGuest") or MdRfPdaGuest
+                        if lg ~= nil and type(lg.onLightTick) == "function" then
+                            light = lg.onLightTick
+                        end
+                    end
+                    if type(light) == "function" then
+                        pcall(light, self.rfHostPlaceholder)
+                    else
+                        pcall(active.onShow, self.rfHostPlaceholder, true)
+                    end
+                end
             else
                 pcall(active.onShow, self.rfHostPlaceholder)
             end
@@ -2121,8 +2771,26 @@ function RfPdaMenuPage:onListSelectionChanged(list, section, index)
             self:_refreshGuestDetail()
         end
     elseif list == self.mdCommodityList and index ~= nil and index > 0 then
-        if MdRfPdaGuest ~= nil and type(MdRfPdaGuest.selectCommodityIndex) == "function" then
-            MdRfPdaGuest.selectCommodityIndex(index)
+        -- Keyboard / controller selection routes through the same real handler as a
+        -- click. No highlight-only path on either.
+        --
+        -- BUILD 13:06 (Vera F1): `active` does not exist in this function - I copied the
+        -- registry-first block out of onClickMdCommodityRow, which defines it, and left the
+        -- two lines that produce it behind. Worse than a miss: `type(active.selectCommodityIndex)`
+        -- INDEXES nil, so arrows and list selection threw every time instead of quietly
+        -- falling through. The click path was fine, which is exactly why it read as working.
+        local host = self:_getHost()
+        local active = host and host.getActivePanel and host:getActivePanel()
+        -- Registry first: a guest that registered the callback needs no resolving.
+        if active ~= nil and type(active.selectCommodityIndex) == "function" then
+            pcall(active.selectCommodityIndex, index)
+        else
+            local mdGuest = (type(mdResolve) == "function")
+                    and mdResolve(MdRfPdaGuest, "MdRfPdaGuest") or MdRfPdaGuest
+            self:_mdLogGuestBelt(mdGuest)
+            if mdGuest ~= nil and type(mdGuest.selectCommodityIndex) == "function" then
+                pcall(mdGuest.selectCommodityIndex, index)
+            end
         end
     elseif list == self.moduleList then
         -- Highlight-only: SmoothList ↑↓ must NOT switch modules.
@@ -2245,19 +2913,78 @@ function RfPdaMenuPage:onClickMdCommodityRow(element)
     if index == nil or index < 1 then
         return
     end
-    if self.mdCommodityList and self.mdCommodityList.setSelectedIndex then
-        pcall(function() self.mdCommodityList:setSelectedIndex(index) end)
+    -- BUILD 12:32: the optimistic highlight is gone. SmoothListElement publishes no
+    -- setSelectedIndex (established 21:41), so this call never did anything - but it read
+    -- as if the click were handled even when the real handler was missing, which is
+    -- exactly the wrong impression while the trend was not following the pick.
+    local host = self:_getHost()
+    local active = host and host.getActivePanel and host:getActivePanel()
+    if active ~= nil and type(active.selectCommodityIndex) == "function" then
+        pcall(active.selectCommodityIndex, index)
+        return
     end
-    if MdRfPdaGuest ~= nil and type(MdRfPdaGuest.selectCommodityIndex) == "function" then
-        MdRfPdaGuest.selectCommodityIndex(index)
+    local mdGuest = (type(mdResolve) == "function")
+            and mdResolve(MdRfPdaGuest, "MdRfPdaGuest") or MdRfPdaGuest
+    self:_mdLogGuestBelt(mdGuest)
+    if mdGuest ~= nil and type(mdGuest.selectCommodityIndex) == "function" then
+        pcall(mdGuest.selectCommodityIndex, index)
     end
 end
 
-function RfPdaMenuPage:onClickMdOpenMarket()
-    if MdRfPdaGuest ~= nil and type(MdRfPdaGuest.onOpenFullMarket) == "function" then
-        MdRfPdaGuest.onOpenFullMarket()
-    elseif MDMMarketScreen ~= nil and type(MDMMarketScreen.show) == "function" then
-        MDMMarketScreen.show()
+--- One-shot: name the belt the guest resolved through, or say it did not resolve.
+--- Same shape as the graph GATE line, because the graph turned out to be findable only
+--- once MarketDynamics published it - the guest was one build behind the same lesson.
+function RfPdaMenuPage:_mdLogGuestBelt(mdGuest)
+    if self._mdGuestBeltLogged then
+        return
     end
+    self._mdGuestBeltLogged = true
+    local via = "nil"
+    if mdGuest ~= nil then
+        if MdRfPdaGuest ~= nil then
+            via = "in-env"
+        elseif g_modEnvironments ~= nil and g_modEnvironments["FS25_MarketDynamics"] ~= nil
+                and g_modEnvironments["FS25_MarketDynamics"].MdRfPdaGuest ~= nil then
+            via = "modEnv-named"
+        else
+            local okE, rootE = pcall(getfenv, 0)
+            if okE and type(rootE) == "table" and rootE.MdRfPdaGuest ~= nil then
+                via = "getfenv0"
+            elseif g_currentMission ~= nil and g_currentMission.MdRfPdaGuest ~= nil then
+                via = "mission"
+            else
+                via = "modEnv-scan"
+            end
+        end
+    end
+    print(string.format(
+        "[MarketDynamics] Esc guest: resolved=%s via=%s selectCommodityIndex=%s",
+        tostring(mdGuest ~= nil), via,
+        tostring(mdGuest ~= nil and type(mdGuest.selectCommodityIndex) == "function")))
+end
+
+function RfPdaMenuPage:onClickMdOpenMarket()
+    -- BUILD 12:59: was the last bare cross-mod read in this file. Under a foreign door
+    -- both names were nil, so the button did nothing at all - silently, which is the
+    -- worst version. Registry first, then the resolver, and it cannot throw.
+    local host = self:_getHost()
+    local active = host and host.getActivePanel and host:getActivePanel()
+    if active ~= nil and type(active.onOpenFullMarket) == "function" then
+        pcall(active.onOpenFullMarket)
+        return
+    end
+    local guest = (type(mdResolve) == "function")
+            and mdResolve(MdRfPdaGuest, "MdRfPdaGuest") or MdRfPdaGuest
+    if guest ~= nil and type(guest.onOpenFullMarket) == "function" then
+        pcall(guest.onOpenFullMarket)
+        return
+    end
+    local screen = (type(mdResolve) == "function")
+            and mdResolve(MDMMarketScreen, "MDMMarketScreen") or MDMMarketScreen
+    if screen ~= nil and type(screen.show) == "function" then
+        pcall(screen.show)
+    end
+    -- Companion absent: quiet no-op. "Works alone" means a missing peer is silence,
+    -- not an error out of a click handler.
 end
 

--- a/src/gui/TaxRfPdaGuest.lua
+++ b/src/gui/TaxRfPdaGuest.lua
@@ -154,9 +154,77 @@ local function monthsUntil(target, current)
     return d
 end
 
+local _guiWarned = false
+local _baseline = nil   -- captured once, before the first move, for onHide restore
+
+-- Wizard eyes-on: Status posture moves out of the top band into the lower empty band,
+-- with bigger type. Left column = lines 1-4 at x=0, right column = lines 5-8 at x=580.
+local TAX_LINE_POS = {
+    [1] = { "0px",   "-280px" }, [5] = { "580px", "-280px" },
+    [2] = { "0px",   "-328px" }, [6] = { "580px", "-328px" },
+    [3] = { "0px",   "-376px" }, [7] = { "580px", "-376px" },
+    [4] = { "0px",   "-424px" }, [8] = { "580px", "-424px" },
+}
+local TAX_HINT_POS  = { "0px", "-480px" }
+local TAX_TEXT_SIZE = "26px"
+
+--- position and textSize are NORMALISED in FS25 (TextElement default textSize is 0.03),
+--- so raw pixel numbers would throw the layout off-screen. Always go through GuiUtils.
+--- Nil-safe: if the normalizer is missing we leave the XML baseline rather than guess.
+local function guiOk()
+    if GuiUtils == nil or type(GuiUtils.getNormalizedXValue) ~= "function"
+        or type(GuiUtils.getNormalizedYValue) ~= "function" then
+        if not _guiWarned then
+            _guiWarned = true
+            print("[TaxMod] TaxRfPdaGuest: GuiUtils normalizer absent - leaving Status lines at XML baseline")
+        end
+        return false
+    end
+    return true
+end
+
+--- Remember where the shared Status shell started, once, so onHide can put it back.
+local function captureBaseline(container)
+    if _baseline ~= nil then return end
+    _baseline = {}
+    for i = 1, 8 do
+        local el = findDescendant(container, "rfFwLine" .. i)
+        if el ~= nil then
+            _baseline["rfFwLine" .. i] = { x = el.position and el.position[1], y = el.position and el.position[2],
+                                           textSize = el.textSize }
+        end
+    end
+    local h = findDescendant(container, "rfFwHint")
+    if h ~= nil then
+        _baseline.rfFwHint = { x = h.position and h.position[1], y = h.position and h.position[2], textSize = h.textSize }
+    end
+end
+
+local function applyStatusBand(container)
+    if not guiOk() then return end
+    captureBaseline(container)
+    local size = GuiUtils.getNormalizedYValue(TAX_TEXT_SIZE, nil)
+    for i = 1, 8 do
+        local el = findDescendant(container, "rfFwLine" .. i)
+        local pos = TAX_LINE_POS[i]
+        if el ~= nil and pos ~= nil and type(el.setPosition) == "function" then
+            el:setPosition(GuiUtils.getNormalizedXValue(pos[1], 0), GuiUtils.getNormalizedYValue(pos[2], 0))
+            if size ~= nil and type(el.setTextSize) == "function" then el:setTextSize(size) end
+            if type(el.updateAbsolutePosition) == "function" then el:updateAbsolutePosition() end
+        end
+    end
+    local h = findDescendant(container, "rfFwHint")
+    if h ~= nil and type(h.setPosition) == "function" then
+        h:setPosition(GuiUtils.getNormalizedXValue(TAX_HINT_POS[1], 0), GuiUtils.getNormalizedYValue(TAX_HINT_POS[2], 0))
+        if size ~= nil and type(h.setTextSize) == "function" then h:setTextSize(size) end
+        if type(h.updateAbsolutePosition) == "function" then h:updateAbsolutePosition() end
+    end
+end
+
 function TaxRfPdaGuest.onShow(container, lightOnly)
     clearHostDupes(container)
     showStatusMode(container)
+    applyStatusBand(container)
     paintSide(container, "rf_pda_side_info_tax",
         "Tax posture: on/off, year bill, March estimate, balance share, countdown.\n"
         .. "Daily rate and March rate differ. Esc never pays tax - use Tax HUD / Settings.")
@@ -247,7 +315,23 @@ function TaxRfPdaGuest.onShow(container, lightOnly)
     setText(findDescendant(container, "rfFwHint"), hint)
 end
 
-function TaxRfPdaGuest.onHide() end
+--- Restore the Status shell to the baseline captured before the first move.
+--- Status is currently tax-only (host maps isFwStatus = "tax"), so nothing else can be
+--- stranded by these moves - but no host calls onHide today (verified across the suite),
+--- so this is correct-when-wired rather than live. onShow re-applies the band every time.
+function TaxRfPdaGuest.onHide(container)
+    if container == nil or _baseline == nil then return end
+    local function restore(id)
+        local b = _baseline[id]
+        local el = findDescendant(container, id)
+        if b == nil or el == nil then return end
+        if b.x ~= nil and b.y ~= nil and type(el.setPosition) == "function" then el:setPosition(b.x, b.y) end
+        if b.textSize ~= nil and type(el.setTextSize) == "function" then el:setTextSize(b.textSize) end
+        if type(el.updateAbsolutePosition) == "function" then el:updateAbsolutePosition() end
+    end
+    for i = 1, 8 do restore("rfFwLine" .. i) end
+    restore("rfFwHint")
+end
 
 function TaxRfPdaGuest.tryRegister()
     if RfEscBootstrap ~= nil then

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -38,8 +38,8 @@
                 <!-- Soil/CS left info (George: inside rfFilterBox, BEFORE moduleList; Text + blank.png). -->
                 <GuiElement profile="RF_SideInfoShell" id="rfSideInfoShell" visible="false" handleFocus="false">
                     <Bitmap profile="RF_InfoBoxBg" handleFocus="false"/>
-                    <Text profile="RF_SideInfoBody" id="rfSideInfoBody" position="8px -8px" size="368px 284px"
-                          textMaxNumLines="16" textVerticalAlignment="top" text=""/>
+                    <Text profile="RF_SideInfoBody" id="rfSideInfoBody" position="8px -8px" size="368px 644px"
+                          textMaxNumLines="36" textVerticalAlignment="top" text=""/>
                 </GuiElement>
 
                 <GuiElement profile="fs25_subCategoryListContainer" id="rfModuleListShell">
@@ -96,6 +96,30 @@
                 </GuiElement>
             </GuiElement>
 
+            <!-- CS page chrome (BUILD 18:48): Fields | Pivot. Straight twin of the WC and
+                 MDM subnavs - sibling under Modules, never inside rfFilterBox, host-owned.
+                 csSubnavShell is RETIRED as of BUILD 21:06: Crop Stress is one desk and the
+                 Fields | Pivot selector selected nothing, so the host never shows it. Kept in
+                 place so the ids bind and the WC / MDM twins keep their shared profiles. -->
+            <GuiElement profile="RF_WcSubnavShell" id="csSubnavShell" visible="false">
+                <MultiTextOption profile="RF_WcSubnavSelector" id="csSubnavSelector"
+                                 disableButtonsOnSingleText="false"
+                                 onClick="onClickCsSubnavSelector"/>
+                <BoxLayout profile="RF_WcSubnavDotBox" id="csSubnavDotBox" visible="false">
+                    <RoundCorner profile="fs25_subCategorySelectorDot"/>
+                </BoxLayout>
+                <!-- RETIRED BUILD 21:06. The CS teach moved back to rfSideInfoShell in
+                     rfFilterBox once the subnav it was avoiding was retired. This element is
+                     kept, never shown, and cleared every refresh, so the id still binds and a
+                     stale nested copy cannot surface behind the live one. -->
+                <GuiElement profile="RF_WcSideInfoShell" id="csSideInfoShell" visible="false"
+                            handleFocus="false" clipChildren="true">
+                    <Bitmap profile="RF_InfoBoxBg" handleFocus="false"/>
+                    <Text profile="RF_WcSideBody" id="csSideInfoBody" position="8px -8px" size="364px 224px"
+                          textMaxNumLines="12" textVerticalAlignment="top" text=""/>
+                </GuiElement>
+            </GuiElement>
+
             <!-- RIGHT: suite content plane (RF_MainColShell flushes X˜406 to side-info right). -->
             <GuiElement profile="RF_MainColShell" id="rfMainCol">
                 <GuiElement profile="fs25_menuHeaderPanel" position="0px 74px">
@@ -123,14 +147,17 @@
 
                         <!-- F12: all headers centered; AREA/STATUS/Fertilizer body centered.
                              IDs: Lua _applyChromeL10n rebinds when CS/WC created the Esc door. -->
-                        <Text profile="RF_ColHeader" id="soilColField"  text="$l10n_sf_pda_col_field"  position="16px -8px"    size="100px 24px"/>
-                        <Text profile="RF_ColHeader" id="soilColArea"   text="$l10n_rf_pda_col_area"   position="120px -8px"   size="100px 24px"/>
-                        <Text profile="RF_ColHeader" text="N"                       position="230px -8px"   size="110px 24px"/>
-                        <Text profile="RF_ColHeader" text="P"                       position="350px -8px"   size="110px 24px"/>
-                        <Text profile="RF_ColHeader" text="K"                       position="470px -8px"   size="110px 24px"/>
-                        <Text profile="RF_ColHeader" id="soilColPH" text="pH"       position="590px -8px"   size="100px 24px"/>
-                        <Text profile="RF_ColHeader" id="soilColStatus" text="$l10n_sf_pda_col_status" position="700px -8px"   size="140px 24px"/>
-                        <Text profile="RF_ColHeader" id="soilColFert"   text="$l10n_rf_pda_col_fert"   position="860px -8px"  size="160px 24px"/>
+                        <Text profile="RF_ColHeader" id="soilColField"  text="$l10n_sf_pda_col_field"  position="12px -8px"    size="102px 24px"/>
+                        <Text profile="RF_ColHeader" id="soilColArea"   text="$l10n_rf_pda_col_area"   position="120px -8px"   size="102px 24px"/>
+                        <Text profile="RF_ColHeader" text="N"                       position="230px -8px"   size="84px 24px"/>
+                        <Text profile="RF_ColHeader" text="P"                       position="322px -8px"   size="84px 24px"/>
+                        <Text profile="RF_ColHeader" text="K"                       position="414px -8px"   size="84px 24px"/>
+                        <Text profile="RF_ColHeader" id="soilColPH" text="pH"       position="506px -8px"   size="72px 24px"/>
+                        <Text profile="RF_ColHeader" id="soilColStatus" text="$l10n_sf_pda_col_status" position="586px -8px"   size="108px 24px"/>
+                        <Text profile="RF_ColHeader" id="soilColFert"   text="$l10n_rf_pda_col_fert"   position="702px -8px"  size="106px 24px"/>
+                        <Text profile="RF_ColHeader" id="soilColWeed"    text="$l10n_sf_pda_col_weeds"   position="816px -8px"  size="94px 24px"/>
+                        <Text profile="RF_ColHeader" id="soilColPest"    text="$l10n_sf_pda_col_pests"   position="918px -8px"  size="94px 24px"/>
+                        <Text profile="RF_ColHeader" id="soilColDisease" text="$l10n_sf_pda_col_disease" position="1020px -8px"  size="120px 24px"/>
 
                         <GuiElement profile="fs25_subCategoryListContainer" position="0px -32px"
                                     absoluteSizeOffset="0px 40px">
@@ -139,14 +166,17 @@
                                         endClipperElementName="rfListEnd">
                                 <ListItem profile="RF_ListRowTall" onClick="onClickFieldRow">
                                     <Bitmap profile="RF_RowBg" name="alternating"/>
-                                    <Text profile="RF_CellLeft"   name="fieldRowId"     size="100px 44px"/>
-                                    <Text profile="RF_CellCenter" name="fieldRowArea"   position="120px 0px"  size="100px 44px"/>
-                                    <Text profile="RF_CellRight"  name="fieldRowN"      position="230px 0px"  size="110px 44px"/>
-                                    <Text profile="RF_CellRight"  name="fieldRowP"      position="350px 0px"  size="110px 44px"/>
-                                    <Text profile="RF_CellRight"  name="fieldRowK"      position="470px 0px"  size="110px 44px"/>
-                                    <Text profile="RF_CellRight"  name="fieldRowPH"     position="590px 0px"  size="100px 44px"/>
-                                    <Text profile="RF_StatusCell" name="fieldRowStatus" position="700px 0px" size="140px 44px"/>
-                                    <Text profile="RF_FertChip"   name="fieldRowFert"   position="860px 0px" size="160px 44px"/>
+                                    <Text profile="RF_CellLeft"   name="fieldRowId"     position="12px 0px"   size="102px 48px"/>
+                                    <Text profile="RF_CellCenter" name="fieldRowArea"   position="120px 0px"  size="102px 48px"/>
+                                    <Text profile="RF_CellRight"  name="fieldRowN"      position="230px 0px"  size="84px 48px"/>
+                                    <Text profile="RF_CellRight"  name="fieldRowP"      position="322px 0px"  size="84px 48px"/>
+                                    <Text profile="RF_CellRight"  name="fieldRowK"      position="414px 0px"  size="84px 48px"/>
+                                    <Text profile="RF_CellRight"  name="fieldRowPH"     position="506px 0px"  size="72px 48px"/>
+                                    <Text profile="RF_StatusCell" name="fieldRowStatus" position="586px 0px" size="108px 48px"/>
+                                    <Text profile="RF_FertChip"   name="fieldRowFert"   position="702px 0px" size="106px 48px"/>
+                                    <Text profile="RF_CellRight"  name="fieldRowWeed"    position="816px 0px" size="94px 48px"/>
+                                    <Text profile="RF_CellRight"  name="fieldRowPest"    position="918px 0px" size="94px 48px"/>
+                                    <Text profile="RF_CellRight"  name="fieldRowDisease" position="1020px 0px" size="120px 48px"/>
                                 </ListItem>
                             </SmoothList>
                             <Bitmap profile="fs25_secondaryMenuStartClipper" name="rfListStart"/>
@@ -163,85 +193,127 @@
                     <!-- TREATMENT PLAN (F8: clip shell keeps PRODUCTS rows inside panel) -->
                     <GuiElement profile="RF_TreatmentStrip" id="rfTreatmentStrip">
                         <Bitmap profile="RF_TreatmentBoxBg"/>
-                        <Text profile="RF_SectionTitle" id="soilSectionTreatment" position="10px -6px" text="$l10n_rf_pda_section_treatment"/>
-
-                        <!-- Col 1: vertical target stack (F11 positions held; Selected field moved right) -->
-                        <Text profile="RF_TreatTargetLine" id="treatTargetsHeading" position="10px -56px" size="250px 20px"/>
-                        <Text profile="RF_TreatTargetLine" id="treatTargetN" position="10px -88px" size="250px 20px"/>
-                        <Text profile="RF_TreatTargetLine" id="treatTargetP" position="10px -120px" size="250px 20px"/>
-                        <Text profile="RF_TreatTargetLine" id="treatTargetK" position="10px -152px" size="250px 20px"/>
+                        <!-- Card 1 of 3 (BUILD 12:59): TREATMENT + target levels share the
+                             -22 top line with PRODUCTS and ROTATION. Children re-based inside. -->
+                        <GuiElement profile="RF_EscCardFrame" id="soilTreatmentCard" position="10px -22px" size="200px 248px">
+                            <Text profile="RF_SectionTitle" id="soilSectionTreatment" position="10px -6px" size="180px 24px" text="$l10n_rf_pda_section_treatment"/>
+                            <Text profile="RF_TreatTargetLine" id="treatTargetsHeading" position="10px -40px" size="180px 20px"/>
+                            <Text profile="RF_TreatTargetLine" id="treatTargetN" position="10px -62px" size="180px 20px"/>
+                            <Text profile="RF_TreatTargetLine" id="treatTargetP" position="10px -84px" size="180px 20px"/>
+                            <Text profile="RF_TreatTargetLine" id="treatTargetK" position="10px -106px" size="180px 20px"/>
+                            <Text profile="RF_TreatTargetLine" id="treatTargetPH" position="10px -128px" size="180px 20px"/>
+                        </GuiElement>
                         <!-- Legacy bind kept hidden (F5 replaces single multiline Text) -->
                         <Text profile="RF_HintText" id="treatTargetsLabel" position="10px -54px" size="1px 1px"
                               visible="false"/>
 
-                        <!-- Eyes-on 2026-08-03: Field on line 1, Next tip on line 2 (separate Text ids). -->
-                        <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="270px -22px" size="560px 20px"
-                              textAlignment="left"/>
-                        <Text profile="RF_TreatNext" id="treatNextLabel" position="270px -42px" size="560px 40px"
-                              textAlignment="left" textMaxNumLines="2" textVerticalAlignment="top"/>
-
-                        <!-- Col 2: PRODUCTS table — wider Name; Rate/Total kept readable (no SmoothList) -->
-                        <GuiElement profile="RF_ProductsShell" id="treatProductsShell" position="270px -88px">
-                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="0px 0px" size="560px 18px"
+                        <!-- Card 2 of 3 (BUILD 12:59): Selected + Next now live INSIDE the
+                             PRODUCTS card, so the card owns the whole middle column. -->
+                        <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px">
+                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="540px 20px"
+                                  textAlignment="left"/>
+                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="540px 36px"
+                                  textAlignment="left" textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then ~16px of
+                                 air with one 1px hairline centred in it, then the PRODUCTS table.
+                                 One outer outline only; the rule is a Bitmap, not a second frame.
+                                 Bodies inset X 0 -> 10 and widths 560 -> 540 so nothing kisses the
+                                 white stroke on either side. -->
+                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="540px 1px"/>
+                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="540px 18px"
                                   text="$l10n_rf_pda_treat_products"/>
-                            <Text profile="RF_ProductColHeader" position="0px -20px" size="40px 16px" text="NUT"/>
-                            <Text profile="RF_ProductColHeader" position="44px -20px" size="290px 16px" text="PRODUCT"/>
-                            <Text profile="RF_ProductColHeader" position="340px -20px" size="100px 16px"
+                            <Text profile="RF_ProductColHeaderDense" position="10px -100px" size="40px 16px" text="NUT"/>
+                            <Text profile="RF_ProductColHeaderDense" position="54px -100px" size="270px 16px" text="PRODUCT"/>
+                            <Text profile="RF_ProductColHeaderDense" position="330px -100px" size="100px 16px"
                                   textAlignment="right" text="RATE"/>
-                            <Text profile="RF_ProductColHeader" position="450px -20px" size="100px 16px"
+                            <Text profile="RF_ProductColHeaderDense" position="440px -100px" size="110px 16px"
                                   textAlignment="right" text="TOTAL"/>
-                            <Text profile="RF_ProductOk" id="treatPlanLines" position="0px -40px" size="560px 22px"
+                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="540px 22px"
                                   visible="false"/>
-                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="0px -40px">
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" visible="false">
-                                    <Text profile="RF_ProductCell" id="treatProd1Nut" position="0px 0px" size="40px 20px"/>
-                                    <Text profile="RF_ProductCell" id="treatProd1Name" position="44px 0px" size="290px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd1Rate" position="340px 0px" size="100px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd1Total" position="450px 0px" size="100px 20px"/>
+                            <!-- Clip sized to exactly the eight densified rows (8 x 15 = 120), so the
+                                 card bottom keeps 8px of air instead of cutting row 8 mid-glyph. -->
+                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="540px 120px">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="540px 15px" visible="false">
+                                    <Text profile="RF_ProductCellDense" id="treatProd1Nut" position="0px 0px" size="40px 15px"/>
+                                    <Text profile="RF_ProductCellDense" id="treatProd1Name" position="44px 0px" size="270px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd1Rate" position="320px 0px" size="100px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd1Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow2" position="0px -20px" visible="false">
-                                    <Text profile="RF_ProductCell" id="treatProd2Nut" position="0px 0px" size="40px 20px"/>
-                                    <Text profile="RF_ProductCell" id="treatProd2Name" position="44px 0px" size="290px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd2Rate" position="340px 0px" size="100px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd2Total" position="450px 0px" size="100px 20px"/>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow2" position="0px -15px" size="540px 15px" visible="false">
+                                    <Text profile="RF_ProductCellDense" id="treatProd2Nut" position="0px 0px" size="40px 15px"/>
+                                    <Text profile="RF_ProductCellDense" id="treatProd2Name" position="44px 0px" size="270px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd2Rate" position="320px 0px" size="100px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd2Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow3" position="0px -40px" visible="false">
-                                    <Text profile="RF_ProductCell" id="treatProd3Nut" position="0px 0px" size="40px 20px"/>
-                                    <Text profile="RF_ProductCell" id="treatProd3Name" position="44px 0px" size="290px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd3Rate" position="340px 0px" size="100px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd3Total" position="450px 0px" size="100px 20px"/>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow3" position="0px -30px" size="540px 15px" visible="false">
+                                    <Text profile="RF_ProductCellDense" id="treatProd3Nut" position="0px 0px" size="40px 15px"/>
+                                    <Text profile="RF_ProductCellDense" id="treatProd3Name" position="44px 0px" size="270px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd3Rate" position="320px 0px" size="100px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd3Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow4" position="0px -60px" visible="false">
-                                    <Text profile="RF_ProductCell" id="treatProd4Nut" position="0px 0px" size="40px 20px"/>
-                                    <Text profile="RF_ProductCell" id="treatProd4Name" position="44px 0px" size="290px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd4Rate" position="340px 0px" size="100px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd4Total" position="450px 0px" size="100px 20px"/>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow4" position="0px -45px" size="540px 15px" visible="false">
+                                    <Text profile="RF_ProductCellDense" id="treatProd4Nut" position="0px 0px" size="40px 15px"/>
+                                    <Text profile="RF_ProductCellDense" id="treatProd4Name" position="44px 0px" size="270px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd4Rate" position="320px 0px" size="100px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd4Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow5" position="0px -80px" visible="false">
-                                    <Text profile="RF_ProductCell" id="treatProd5Nut" position="0px 0px" size="40px 20px"/>
-                                    <Text profile="RF_ProductCell" id="treatProd5Name" position="44px 0px" size="290px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd5Rate" position="340px 0px" size="100px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd5Total" position="450px 0px" size="100px 20px"/>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow5" position="0px -60px" size="540px 15px" visible="false">
+                                    <Text profile="RF_ProductCellDense" id="treatProd5Nut" position="0px 0px" size="40px 15px"/>
+                                    <Text profile="RF_ProductCellDense" id="treatProd5Name" position="44px 0px" size="270px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd5Rate" position="320px 0px" size="100px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd5Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow6" position="0px -100px" visible="false">
-                                    <Text profile="RF_ProductCell" id="treatProd6Nut" position="0px 0px" size="40px 20px"/>
-                                    <Text profile="RF_ProductCell" id="treatProd6Name" position="44px 0px" size="290px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd6Rate" position="340px 0px" size="100px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd6Total" position="450px 0px" size="100px 20px"/>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow6" position="0px -75px" size="540px 15px" visible="false">
+                                    <Text profile="RF_ProductCellDense" id="treatProd6Nut" position="0px 0px" size="40px 15px"/>
+                                    <Text profile="RF_ProductCellDense" id="treatProd6Name" position="44px 0px" size="270px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd6Rate" position="320px 0px" size="100px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd6Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow7" position="0px -120px" visible="false">
-                                    <Text profile="RF_ProductCell" id="treatProd7Nut" position="0px 0px" size="40px 20px"/>
-                                    <Text profile="RF_ProductCell" id="treatProd7Name" position="44px 0px" size="290px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd7Rate" position="340px 0px" size="100px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd7Total" position="450px 0px" size="100px 20px"/>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow7" position="0px -90px" size="540px 15px" visible="false">
+                                    <Text profile="RF_ProductCellDense" id="treatProd7Nut" position="0px 0px" size="40px 15px"/>
+                                    <Text profile="RF_ProductCellDense" id="treatProd7Name" position="44px 0px" size="270px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd7Rate" position="320px 0px" size="100px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd7Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow8" position="0px -140px" visible="false">
-                                    <Text profile="RF_ProductCell" id="treatProd8Nut" position="0px 0px" size="40px 20px"/>
-                                    <Text profile="RF_ProductCell" id="treatProd8Name" position="44px 0px" size="290px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd8Rate" position="340px 0px" size="100px 20px"/>
-                                    <Text profile="RF_ProductCellRight" id="treatProd8Total" position="450px 0px" size="100px 20px"/>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow8" position="0px -105px" size="540px 15px" visible="false">
+                                    <Text profile="RF_ProductCellDense" id="treatProd8Nut" position="0px 0px" size="40px 15px"/>
+                                    <Text profile="RF_ProductCellDense" id="treatProd8Name" position="44px 0px" size="270px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd8Rate" position="320px 0px" size="100px 15px"/>
+                                    <Text profile="RF_ProductCellDenseRight" id="treatProd8Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
                             </GuiElement>
+                        </GuiElement>
+
+                        <!-- Col 3: read-only rotation glance + What-if (Wizard eyes-on 2026-08-08 pics 1-3,
+                             Samantha DESIGN + George ENGINE ACK). Footprint held at George's
+                             850px -88px / 290px 248px - never grows left into PRODUCTS.
+                             Soil grey via RF_TreatmentBoxBg (mock blue vetoed). Fixed Text only,
+                             no SmoothList. Read-only: no apply-rotation controls. -->
+                        <GuiElement profile="RF_EscCardFrame" id="soilRotationCard" position="850px -22px" size="290px 248px">
+                            <!-- Zone split (BUILD 16:19): ROTATION glance on top, then 14px of air
+                                 with one 1px hairline, then WHAT IF. Same recipe as the middle card
+                                 so the two read as one family. All bodies inset X 0 -> 10, widths
+                                 290 -> 270, title Y 0 -> -10, standing block shifted 10px down to
+                                 keep its spacing under the lowered title. -->
+                            <Text profile="RF_ProductsTitle" id="soilRotationTitle" position="10px -10px" size="270px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationLast" position="10px -34px" size="270px 20px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationStatus" position="10px -56px" size="270px 20px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationTip" position="10px -76px" size="270px 32px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Bitmap profile="RF_EscCardRule" id="soilRotationRule" position="10px -116px" size="270px 1px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationWhatIfHeader" position="10px -124px" size="270px 16px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColCrop" position="10px -144px" size="92px 14px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColStatus" position="106px -144px" size="60px 14px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColEffect" position="170px -144px" size="110px 14px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf1Crop" position="10px -162px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf1Status" position="106px -162px" size="60px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf1Effect" position="170px -162px" size="110px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf2Crop" position="10px -184px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf2Status" position="106px -184px" size="60px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf2Effect" position="170px -184px" size="110px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf3Crop" position="10px -206px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf3Status" position="106px -206px" size="60px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf3Effect" position="170px -206px" size="110px 18px"/>
                         </GuiElement>
 
                         <!-- Col 3: sampling — shifted right so widened PRODUCTS does not overlap -->
@@ -347,15 +419,15 @@
                     <GuiElement profile="RF_WcPageShell" id="rfFrameworkGlanceShell" visible="false" position="0px 0px">
                         <GuiElement id="rfFwStatusBlock" visible="true" position="0px 0px" size="1140px 580px">
                             <Text profile="RF_SectionTitle" id="rfFwStatusTitle" position="0px 0px" size="1140px 24px" text="" visible="false"/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine1" position="0px 0px" size="1140px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine2" position="0px -48px" size="1140px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine3" position="0px -96px" size="1140px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine4" position="0px -144px" size="1140px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine5" position="0px -192px" size="1140px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine6" position="0px -240px" size="1140px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine7" position="0px -288px" size="1140px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine8" position="0px -336px" size="1140px 22px" text=""/>
-                            <Text profile="RF_HintText" id="rfFwHint" position="0px -384px" size="1140px 120px"
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine1" position="0px 0px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine2" position="0px -48px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine3" position="0px -96px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine4" position="0px -144px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine5" position="580px 0px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine6" position="580px -48px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine7" position="580px -96px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine8" position="580px -144px" size="560px 22px" text=""/>
+                            <Text profile="RF_HintText" id="rfFwHint" position="0px -200px" size="1140px 120px"
                                   textMaxNumLines="4" textVerticalAlignment="top" text=""/>
                         </GuiElement>
                         <GuiElement id="rfFwTableBlock" visible="false" position="0px 0px" size="1140px 580px">
@@ -406,8 +478,55 @@
 
                     <!-- CS table: top-flush with 404 bottom reserve so the last rows clear the
                          FIELD DETAIL band title (CS FieldDetail fix, applied in the HOST page). -->
-                    <GuiElement profile="RF_TableRegionShell" id="rfHostTableRegion" position="0px 0px"
-                                absoluteSizeOffset="0px 404px">
+                    <GuiElement profile="emptyPanel" id="csActionBar" position="0px 0px" size="1140px 44px">
+                        <!-- BUILD 18:48: this button owned the table-hiding consultant swap, which
+                             is now a hard engine VETO. Hidden rather than deleted so any stale
+                             binding still resolves; its job belongs to the Fields|Pivot subnav. -->
+                        <Button profile="buttonActivate" id="csBtnConsultant" position="884px -4px" size="256px 36px"
+                                visible="false" text="" onClick="onClickCsConsultant"/>
+                    </GuiElement>
+
+                    <!-- Inline Alex Chen consultant readout. Exclusive with rfHostTableRegion:
+                         csBtnConsultant toggles which of the two is visible. Fixed Texts only -
+                         George NO-GO on TextElement.new rebuild, dialog XML nest, or SmoothList. -->
+                    <GuiElement profile="RF_TableRegionShell" id="csConsultPanel" position="0px -44px"
+                                absoluteSizeOffset="0px 584px" visible="false">
+                        <Text profile="RF_SectionTitle"   id="csConsTitle"    position="16px -12px"  size="700px 26px"  text=""/>
+                        <Text profile="RF_TreatTargetLine" id="csConsRelation" position="16px -36px"  size="1140px 20px" visible="false" text=""/>
+                        <Text profile="RF_ColHeader" id="csConsColField"    position="16px -64px"  size="280px 22px" text=""/>
+                        <Text profile="RF_ColHeader" id="csConsColRisk"     position="300px -64px" size="220px 22px" text=""/>
+                        <Text profile="RF_ColHeader" id="csConsColMoisture" position="540px -64px" size="240px 22px" text=""/>
+                        <Text profile="RF_ColHeader" id="csConsColYield"    position="800px -64px" size="340px 22px" text=""/>
+                        <Text profile="RF_CellLeft"   id="csConsRow1Field"    position="16px -88px"  size="280px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow1Risk"     position="300px -88px" size="220px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow1Moisture" position="540px -88px" size="240px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow1Yield"    position="800px -88px" size="340px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellLeft"   id="csConsRow2Field"    position="16px -112px"  size="280px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow2Risk"     position="300px -112px" size="220px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow2Moisture" position="540px -112px" size="240px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow2Yield"    position="800px -112px" size="340px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellLeft"   id="csConsRow3Field"    position="16px -136px"  size="280px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow3Risk"     position="300px -136px" size="220px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow3Moisture" position="540px -136px" size="240px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow3Yield"    position="800px -136px" size="340px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellLeft"   id="csConsRow4Field"    position="16px -160px"  size="280px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow4Risk"     position="300px -160px" size="220px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow4Moisture" position="540px -160px" size="240px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow4Yield"    position="800px -160px" size="340px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellLeft"   id="csConsRow5Field"    position="16px -184px"  size="280px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow5Risk"     position="300px -184px" size="220px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow5Moisture" position="540px -184px" size="240px 22px" visible="false" text=""/>
+                        <Text profile="RF_CellCenter" id="csConsRow5Yield"    position="800px -184px" size="340px 22px" visible="false" text=""/>
+                        <Text profile="RF_SectionTitle"    id="csConsRecTitle" position="16px -210px" size="500px 24px"  text=""/>
+                        <Text profile="RF_TreatTargetLine" id="csConsRec1"     position="16px -236px" size="1140px 22px" visible="false" text=""/>
+                        <Text profile="RF_TreatTargetLine" id="csConsRec2"     position="16px -258px" size="1140px 22px" visible="false" text=""/>
+                        <Text profile="RF_TreatTargetLine" id="csConsRec3"     position="16px -280px" size="1140px 22px" visible="false" text=""/>
+                        <Text profile="RF_HintText" id="csConsEmpty" position="16px -140px" size="1000px 44px"
+                              textMaxNumLines="2" visible="false" text=""/>
+                    </GuiElement>
+
+                    <GuiElement profile="RF_TableRegionShell" id="rfHostTableRegion" position="0px -44px"
+                                absoluteSizeOffset="0px 584px">
                         <Text profile="RF_ColHeader" id="csColField" text="" position="16px -8px" size="100px 24px"/>
                         <Text profile="RF_ColHeader" id="csColCrop" text="" position="140px -8px" size="200px 24px"/>
                         <Text profile="RF_ColHeader" id="csColMoisture" text="" position="360px -8px" size="160px 24px"/>
@@ -441,20 +560,109 @@
                               position="16px -80px" size="1100px 44px" visible="false"/>
                     </GuiElement>
 
-                    <!-- CS bottom info band: twin Soil strip chrome, Text-only detail for the
-                         selected field (no SmoothList in band; no Soil PRODUCTS/NPK content).
-                         Texts filled by CsRfPdaGuest; safe on light tick. -->
-                    <GuiElement profile="RF_TreatmentStrip" id="csDetailStrip">
+                    <!-- CS bottom band pivot full-width (2026-08-09): FD|Agro top; Pivot full width bottom.
+                         Abs: Field 10/-16/600×236; Agro 630/-16/510×236; Pivot 10/-264/1130×240.
+                         CS-only strip H=520; Soil stays 384. No SmoothList under cards. -->
+                    <GuiElement profile="RF_CsDetailStrip" id="csDetailStrip">
                         <Bitmap profile="RF_TreatmentBoxBg"/>
-                        <Text profile="RF_SectionTitle" id="csDetailTitle" position="10px -6px" size="700px 24px" text=""/>
-                        <Text profile="RF_TreatSelected" id="csDetailField" position="10px -52px" size="900px 22px"
-                              textAlignment="left" text=""/>
-                        <Text profile="RF_TreatTargetLine" id="csDetailMoisture" position="10px -88px" size="420px 20px" text=""/>
-                        <Text profile="RF_TreatTargetLine" id="csDetailStress" position="10px -112px" size="420px 20px" text=""/>
-                        <Text profile="RF_TreatTargetLine" id="csDetailIrrigated" position="10px -136px" size="420px 20px" text=""/>
-                        <Text profile="RF_TreatTargetLine" id="csDetailStatus" position="10px -160px" size="420px 20px" text=""/>
-                        <Text profile="RF_HintText" id="csDetailEmpty" position="10px -52px" size="1000px 44px"
-                              textMaxNumLines="2" visible="false" text=""/>
+
+                        <!-- Field Detail (yellow): top-left; texts ~580 W; densified into 236 H. -->
+                        <GuiElement profile="RF_EscCardFrame" id="csFieldDetailCard" position="10px -16px" size="600px 236px">
+                            <Text profile="RF_SectionTitle" id="csDetailTitle" position="10px -6px" size="580px 18px" text=""/>
+                            <Text profile="RF_TreatSelected" id="csDetailField" position="10px -28px" size="580px 18px"
+                                  textAlignment="left" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="csDetailMoisture" position="10px -50px" size="580px 36px"
+                                  textMaxNumLines="2" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="csDetailStress" position="10px -92px" size="580px 18px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="csDetailIrrigated" position="10px -114px" size="580px 18px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="csDetailStatus" position="10px -136px" size="580px 18px" text=""/>
+                            <Text profile="RF_HintText" id="csDetailEmpty" position="10px -28px" size="580px 44px"
+                                  textMaxNumLines="2" visible="false" text=""/>
+                            <Text profile="RF_HintText" id="csDetailNoCoverage" position="10px -160px" size="580px 36px"
+                                  textMaxNumLines="2" visible="false" text=""/>
+                        </GuiElement>
+
+                        <!-- Agronomist (blue): top-right beside Field Detail; always visible with Pivot on CS. -->
+                        <GuiElement profile="RF_EscCardFrame" id="csAgronomistCard" position="630px -16px" size="510px 236px">
+                            <Text profile="RF_ProductsTitle" id="csAgroTitle" position="10px -6px" size="490px 18px" text=""/>
+                            <Text profile="RF_ProductCell" id="csAgroRelationship" position="10px -28px" size="490px 14px"
+                                  visible="false" text=""/>
+                            <Bitmap profile="RF_EscCardRule" id="csAgroRuleTop" position="10px -46px" size="490px 1px"/>
+                            <Text profile="RF_ProductColHeader" id="csAgroTopHeader" position="10px -50px" size="490px 14px" text=""/>
+                            <Text profile="RF_ProductCellDense" id="csAgroTop1" position="10px -68px" size="490px 14px" text=""/>
+                            <Text profile="RF_ProductCellDense" id="csAgroTop2" position="10px -86px" size="490px 14px" text=""/>
+                            <Text profile="RF_ProductCellDense" id="csAgroTop3" position="10px -104px" size="490px 14px" text=""/>
+                            <Text profile="RF_ProductCellDense" id="csAgroTop4" position="10px -122px" size="490px 14px" text=""/>
+                            <Text profile="RF_ProductCellDense" id="csAgroTop5" position="10px -140px" size="490px 14px" text=""/>
+                            <Bitmap profile="RF_EscCardRule" id="csAgroRuleMid" position="10px -160px" size="490px 1px"/>
+                            <Text profile="RF_ProductColHeader" id="csAgroRecHeader" position="10px -164px" size="490px 14px" text=""/>
+                            <Text profile="RF_ProductCellDense" id="csAgroRec1" position="10px -182px" size="490px 14px" text=""/>
+                            <Text profile="RF_ProductCellDense" id="csAgroRec2" position="10px -198px" size="490px 14px" text=""/>
+                            <Text profile="RF_ProductCellDense" id="csAgroRec3" position="10px -214px" size="490px 14px" text=""/>
+                            <Text profile="RF_HintText" id="csAgroEmpty" position="10px -68px" size="490px 80px"
+                                  textMaxNumLines="4" textVerticalAlignment="top" visible="false" text=""/>
+                        </GuiElement>
+
+                        <!-- Pivot (red): full-width bottom band. Dial+status left; remotes across width.
+                             Children stay inside 1130×240 (strip clipChildren=true). Prefer 80×32. -->
+                        <GuiElement profile="RF_EscCardFrame" id="csPivotCard" position="10px -264px" size="1130px 240px">
+                            <Text profile="RF_ProductsTitle" id="csPivotTitle" position="10px -4px" size="1110px 18px" text=""/>
+                            <!-- Left band: dial + status. -->
+                            <Bitmap profile="RF_CsPivotDialFace" id="csPivotDialFace" position="10px -28px" size="92px 92px"/>
+                            <!-- BUILD 16:44d (Vera F1): inline size overrides the profile via loadFromXML, so the
+                                 short hands had to be set HERE, not only on the profile. 92px face,
+                                 radius 46: arm 31 = 67%, limits 27 = 59%. -->
+                            <!-- BUILD 15:30: hands now BASE on the dial hub instead of hanging from the
+                                 face top, because the rotation origin moved to the bar base (customPivot
+                                 {w/2, 0} in CsRfPdaGuest). Face is 92x92 at 10,-28 so the hub is (56,-74);
+                                 a 31px hand with its base there has its top at -74+31 = -43, and x is
+                                 hub minus half the bar width. Change these three and the pivot maths in
+                                 the guest together - they are one geometry. -->
+                            <Text profile="RF_CsPivotDialLabel" id="csPivotDialLabel" position="10px -14px" size="92px 14px"
+                                  text="$l10n_cs_rf_pda_pivot_dial_position"/>
+                            <Bitmap profile="RF_CsPivotNeedleCur" id="csPivotNeedleCur" position="53.5px -43px" size="5px 31px"/>
+                            <Bitmap profile="RF_CsPivotNeedleMin" id="csPivotNeedleMin" position="54px -47px" size="4px 27px"/>
+                            <Bitmap profile="RF_CsPivotNeedleMax" id="csPivotNeedleMax" position="54px -47px" size="4px 27px"/>
+                            <Bitmap profile="RF_CsPivotHubDot" id="csPivotHubDot" position="53px -71px" size="6px 6px"/>
+                            <Text profile="RF_ProductCell" id="csPivotDialCur" position="114px -30px" size="250px 16px" text=""/>
+                            <Text profile="RF_ProductCell" id="csPivotDialMin" position="114px -50px" size="250px 16px" text=""/>
+                            <Text profile="RF_ProductCell" id="csPivotDialMax" position="114px -70px" size="250px 16px" text=""/>
+                            <Text profile="RF_ProductCell" id="csPivotCoverage" position="114px -96px" size="250px 16px" text=""/>
+                            <Text profile="RF_ProductCell" id="csPivotWatering" position="10px -128px" size="354px 16px" text=""/>
+                            <Text profile="RF_ProductCell" id="csPivotPressure" position="10px -148px" size="354px 16px" text=""/>
+                            <Text profile="RF_ProductCell" id="csPivotRate" position="10px -168px" size="354px 14px" text=""/>
+                            <Text profile="RF_ProductCell" id="csPivotSchedule" position="10px -186px" size="354px 14px" text=""/>
+                            <Text profile="RF_HintText" id="csPivotWarn" position="10px -204px" size="354px 14px" text=""/>
+                            <!-- Right remotes: 80x32, H/V gaps 20 (George ENGINE remote spacing). Same ids/onClick. -->
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnDoor" position="390px -28px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotDoor"/>
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnPower" position="490px -28px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotPower"/>
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnSpray" position="590px -28px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotSpray"/>
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnEndGun" position="690px -28px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotEndGun"/>
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnSpeed" position="790px -28px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotSpeed"/>
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnStart" position="390px -80px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotStart"/>
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnStop" position="490px -80px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotStop"/>
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnMinUp" position="590px -80px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotMinUp"/>
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnMinDn" position="690px -80px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotMinDn"/>
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnMaxUp" position="790px -80px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotMaxUp"/>
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnMaxDn" position="890px -80px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotMaxDn"/>
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnArmPlus" position="390px -132px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotArmPlus"/>
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnArmMinus" position="490px -132px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotArmMinus"/>
+                            <Button profile="RF_CsPivotBtn" id="csBtnSchedule" position="590px -132px" size="530px 32px"
+                                    text="" onClick="onClickCsSchedule"/>
+                        </GuiElement>
                     </GuiElement>
 
                     <!-- MDM TOP: commodities CROP / PRICE / CHANGE (GuiElement SmoothList parent; quiet reload). -->

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -65,7 +65,7 @@
     </Profile>
     <!-- Soil/CS left help (mid-band under Modules MTO; before moduleList in XML). -->
     <Profile name="RF_SideInfoShell" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
-        <size value="384px 300px"/>
+        <size value="384px 660px"/>
         <position value="10px -148px"/>
         <clipChildren value="false"/>
         <handleFocus value="false"/>
@@ -75,7 +75,7 @@
         <textColor value="0.659 0.678 0.702 1"/>
         <textAlignment value="left"/>
         <textVerticalAlignment value="top"/>
-        <textMaxNumLines value="16"/>
+        <textMaxNumLines value="36"/>
     </Profile>
     <!-- Fresh WC: page band = sibling of rfFilterBox; grow height so side info under MTO is not clipped. -->
     <Profile name="RF_WcSubnavShell" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
@@ -273,9 +273,123 @@
         <size value="560px 248px"/>
         <clipChildren value="true"/>
     </Profile>
+
+    <!-- Esc card frame so the three Soil cards read as one family (BUILD 12:59).
+         hasFrame / frameThickness / frame*Color are real GuiElement profile keys
+         (GuiElement.lua loadProfile 176-183) - verified against the decompile,
+         not invented. Thin white rule; the grey fills underneath are unchanged. -->
+    <Profile name="RF_EscCardFrame" extends="RF_ProductsShell">
+        <hasFrame value="true"/>
+        <frameThickness value="1dp 1dp 1dp 1dp"/>
+        <frameLeftColor value="1 1 1 0.85"/>
+        <frameTopColor value="1 1 1 0.85"/>
+        <frameRightColor value="1 1 1 0.85"/>
+        <frameBottomColor value="1 1 1 0.85"/>
+    </Profile>
+
+    <!-- BUILD 16:44c: dial face is the Reinke panel's own POSITION scale, not invented
+         art. Atlas is that mod's textures/ControlDecals.dds (1024x1024); the dial island
+         measured at x288 y354 400x400, which keeps 0/90/180/270 whole and excludes the
+         word POSITION. imageUVs takes the pixel rect and GuiUtils.getUVs normalises it.
+         filename is deliberately absent: CsRfPdaGuest resolves the live Reinke mod path
+         at runtime, so nothing is redistributed and the face simply does not paint when
+         that mod is not installed. -->
+    <!-- BUILD 15:30: the panel prints POSITION above its dial; the UV crop deliberately
+         excludes that word (cropping it in clipped a cardinal), so it is set as text. -->
+    <Profile name="RF_CsPivotDialLabel" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="11px"/>
+        <textBold value="true"/>
+        <textUpperCase value="true"/>
+        <textColor value="0.78 0.80 0.82 1"/>
+        <textAlignment value="center"/>
+        <textVerticalAlignment value="top"/>
+        <textMaxNumLines value="1"/>
+    </Profile>
+
+    <!-- Hub cap: hides where the three bars meet, the way the panel's boss does. -->
+    <Profile name="RF_CsPivotHubDot" extends="baseReference" with="anchorTopLeft pivotTopLeft">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0.86 0.87 0.89 1"/>
+        <size value="6px 6px"/>
+        <handleFocus value="false"/>
+    </Profile>
+
+    <Profile name="RF_CsPivotDialFace" extends="baseReference" with="anchorTopLeft pivotTopLeft">
+        <imageUVs value="288 354 400 400"/>
+        <imageColor value="1 1 1 1"/>
+        <size value="92px 92px"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <!-- BUILD 16:44c current arm: neutral chrome, ~68% radius. Full-radius ray bars replaced by a short hand;
+         suite lime deliberately absent so the dial reads as the world instrument. -->
+    <Profile name="RF_CsPivotNeedleCur" extends="baseReference" with="anchorTopLeft pivotTopLeft">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0.86 0.87 0.89 1"/>
+        <size value="5px 30px"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <!-- BUILD 16:44c LimitA: green, ~59% radius. Full-radius ray bars replaced by a short hand;
+         suite lime deliberately absent so the dial reads as the world instrument. -->
+    <Profile name="RF_CsPivotNeedleMin" extends="baseReference" with="anchorTopLeft pivotTopLeft">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0.35 0.72 0.31 1"/>
+        <size value="4px 26px"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <!-- BUILD 16:44c LimitB: red, ~59% radius. Full-radius ray bars replaced by a short hand;
+         suite lime deliberately absent so the dial reads as the world instrument. -->
+    <Profile name="RF_CsPivotNeedleMax" extends="baseReference" with="anchorTopLeft pivotTopLeft">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0.83 0.24 0.20 1"/>
+        <size value="4px 26px"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <!-- Pivot remotes: buttonActivate plate + hideKeyboardGlyph (SPACE off). Option A fs25_wideButton alone = chrome FAIL. -->
+    <!-- Pivot remotes: vanilla ButtonOverlay SPACE chrome; labels painted as key
+         chips from CsRfPdaGuest, not as TextElement text. The BUILD 23:59 v2
+         colorPreset plate is deliberately gone - it was a different chrome family.
+         iconSize stays non-zero: 0x0 collapses the chip height. -->
+    <Profile name="RF_CsPivotBtn" extends="buttonActivate" with="anchorTopLeft pivotTopLeft">
+        <size value="80px 32px"/>
+        <textSize value="13px"/>
+        <textBold value="true"/>
+        <textUpperCase value="false"/>
+        <fitToContent value="false"/>
+        <textAutoWidth value="false"/>
+        <hideKeyboardGlyph value="true"/>
+        <isTriggerableByGlobalAction value="false"/>
+        <iconSize value="30px 30px"/>
+    </Profile>
     <Profile name="RF_ProductsRowsClip" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
         <size value="560px 160px"/>
         <clipChildren value="true"/>
+    </Profile>
+
+    <!-- BUILD 16:19 card padding + zone splits.
+         RF_EscCardRule: the 1px hairline between a card's upper and lower zone.
+         George ranked "gap only" first and a thin blank.png rule second, both GO;
+         Samantha asked for air AND one rule, so this is the rule half. Real
+         filename + explicit imageColor per the fence (a nil Bitmap paints purple).
+         Size is set per instance because middle is 540 wide and right is 270.
+         RF_ProductCellDense / *Right / RF_ProductColHeaderDense: 14px twins of the
+         normal cells, used ONLY by the middle PRODUCTS rows. Eight rows at the old
+         20px pitch do not fit the 248px card once the split lands, so the rows
+         densify to a 15px pitch and the text drops with them. The right card keeps
+         the original 17px cells because it has the room. -->
+    <Profile name="RF_EscCardRule" extends="baseReference" with="anchorTopLeft pivotTopLeft">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0.478 0.502 0.533 0.55"/>
+        <size value="540px 1px"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <Profile name="RF_ProductCellDense" extends="RF_ProductCell">
+        <textSize value="14px"/>
+    </Profile>
+    <Profile name="RF_ProductCellDenseRight" extends="RF_ProductCellRight">
+        <textSize value="14px"/>
+    </Profile>
+    <Profile name="RF_ProductColHeaderDense" extends="RF_ProductColHeader">
+        <textSize value="14px"/>
     </Profile>
     <Profile name="RF_ProductRow" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
         <size value="560px 20px"/>
@@ -375,7 +489,7 @@
 
     <!-- Table viewport reserve. -->
     <Profile name="RF_TableRegionShell" extends="emptyPanel" with="anchorStretchingYStretchingX pivotTopLeft">
-        <absoluteSizeOffset value="0px 392px"/>
+        <absoluteSizeOffset value="0px 372px"/>
         <position value="0px 0px"/>
     </Profile>
 
@@ -406,6 +520,11 @@
         <height value="384px"/>
         <position value="0px 0px"/>
         <clipChildren value="true"/>
+    </Profile>
+
+    <!-- CS-only taller bottom band (Esc CS breath 2026-08-09). Do not use on Soil/MDM. -->
+    <Profile name="RF_CsDetailStrip" extends="RF_TreatmentStrip">
+        <height value="520px"/>
     </Profile>
 
     <!-- Wizard swatches: blank.png + imageColor (never nil filename); stretch fill parents -->
@@ -514,7 +633,7 @@
 
     <!-- F8: taller rows for +2 textSize -->
     <Profile name="RF_ListRowTall" extends="emptyPanel" with="anchorTopStretchingX pivotTopLeft">
-        <height value="44px"/>
+        <height value="48px"/>
     </Profile>
 
     <!-- F12: STATUS body cells centered. -->


### PR DESCRIPTION
## Summary
Wizard playtest OK. Updates this mod's copy of the shared Esc Realistic Farming pause page.

### Stage A — Cross-mod independence
Host reaches Market Dynamics / Crop Stress helpers via mission publish and registered callbacks (not bare names). Soft-absent peers stay quiet.

### Stage B — Crop Stress PIVOT dial chrome
Shared page carries POSITION dial face/label and hub-pivoted chrome/green/red hands so the dial works whichever mod hosts Esc.

### Stage C — Version
Local tip version from Wizard playtest pack (Tax 1.1.5.54).

## Test plan
- [ ] Esc Realistic Farming opens with this mod present
- [ ] Market Dynamics Prices pick follows plot (if MDM installed)
- [ ] Crop Stress PIVOT dial matches panel POSITION look (if SCS installed)
- [ ] No Esc hang

Sister PRs: one per Esc-capable mod.