### PR TITLE
Esc RF PDA: Tax Status FAILFIX + PRODUCTS–ROTATION freeze (clean)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -4,7 +4,7 @@
          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/NMC-TBone/xml-schema/main/modDesc.xsd">
 
     <author>TisonK</author>
-    <version>1.1.5.57</version>
+    <version>1.1.5.58</version>
 
     <title>
         <en>Tax Mod</en>
@@ -20,96 +20,96 @@
 Adds realistic tax system to your farm.
 
 Features:
-├»┬┐┬¢ Daily tax deductions based on farm balance
-├»┬┐┬¢ Monthly tax returns (percentage of taxes paid)
-├»┬┐┬¢ Three tax rate levels: Low (1%), Medium (2%), High (3%)
-├»┬┐┬¢ Configurable minimum balance threshold
-├»┬┐┬¢ Tax history and statistics tracking
-├»┬┐┬¢ Professional in-game notifications
-├»┬┐┬¢ Fully configurable via console commands
-├»┬┐┬¢ Multiplayer compatible
-├»┬┐┬¢ Settings saved per savegame
-├»┬┐┬¢ Type 'tax' in console for commands
+â”œÂ»â”¬â”â”¬Â¢ Daily tax deductions based on farm balance
+â”œÂ»â”¬â”â”¬Â¢ Monthly tax returns (percentage of taxes paid)
+â”œÂ»â”¬â”â”¬Â¢ Three tax rate levels: Low (1%), Medium (2%), High (3%)
+â”œÂ»â”¬â”â”¬Â¢ Configurable minimum balance threshold
+â”œÂ»â”¬â”â”¬Â¢ Tax history and statistics tracking
+â”œÂ»â”¬â”â”¬Â¢ Professional in-game notifications
+â”œÂ»â”¬â”â”¬Â¢ Fully configurable via console commands
+â”œÂ»â”¬â”â”¬Â¢ Multiplayer compatible
+â”œÂ»â”¬â”â”¬Â¢ Settings saved per savegame
+â”œÂ»â”¬â”â”¬Â¢ Type 'tax' in console for commands
 ]]></en>
 
         <de><![CDATA[
-F├»┬┐┬¢gt ein realistisches Steuersystem zu Ihrer Farm hinzu.
+Fâ”œÂ»â”¬â”â”¬Â¢gt ein realistisches Steuersystem zu Ihrer Farm hinzu.
 
 Funktionen:
-├»┬┐┬¢ T├»┬┐┬¢gliche Steuerabz├»┬┐┬¢ge basierend auf dem Farmguthaben
-├»┬┐┬¢ Monatliche Steuerr├»┬┐┬¢ckzahlungen (Prozentsatz der gezahlten Steuern)
-├»┬┐┬¢ Drei Steuersatzstufen: Niedrig (1%), Mittel (2%), Hoch (3%)
-├»┬┐┬¢ Konfigurierbare Mindestguthabenschwelle
-├»┬┐┬¢ Steuerverlauf und Statistikverfolgung
-├»┬┐┬¢ Professionelle In-Game-Benachrichtigungen
-├»┬┐┬¢ Vollst├»┬┐┬¢ndig ├»┬┐┬¢ber Konsolenbefehle konfigurierbar
-├»┬┐┬¢ Multiplayer-kompatibel
-├»┬┐┬¢ Einstellungen pro Spielstand gespeichert
-├»┬┐┬¢ Geben Sie 'tax' in der Konsole f├»┬┐┬¢r Befehle ein
+â”œÂ»â”¬â”â”¬Â¢ Tâ”œÂ»â”¬â”â”¬Â¢gliche Steuerabzâ”œÂ»â”¬â”â”¬Â¢ge basierend auf dem Farmguthaben
+â”œÂ»â”¬â”â”¬Â¢ Monatliche Steuerrâ”œÂ»â”¬â”â”¬Â¢ckzahlungen (Prozentsatz der gezahlten Steuern)
+â”œÂ»â”¬â”â”¬Â¢ Drei Steuersatzstufen: Niedrig (1%), Mittel (2%), Hoch (3%)
+â”œÂ»â”¬â”â”¬Â¢ Konfigurierbare Mindestguthabenschwelle
+â”œÂ»â”¬â”â”¬Â¢ Steuerverlauf und Statistikverfolgung
+â”œÂ»â”¬â”â”¬Â¢ Professionelle In-Game-Benachrichtigungen
+â”œÂ»â”¬â”â”¬Â¢ Vollstâ”œÂ»â”¬â”â”¬Â¢ndig â”œÂ»â”¬â”â”¬Â¢ber Konsolenbefehle konfigurierbar
+â”œÂ»â”¬â”â”¬Â¢ Multiplayer-kompatibel
+â”œÂ»â”¬â”â”¬Â¢ Einstellungen pro Spielstand gespeichert
+â”œÂ»â”¬â”â”¬Â¢ Geben Sie 'tax' in der Konsole fâ”œÂ»â”¬â”â”¬Â¢r Befehle ein
 ]]></de>
 
         <fr><![CDATA[
-Ajoute un syst├»┬┐┬¢me de taxes r├»┬┐┬¢aliste ├»┬┐┬¢ votre ferme.
+Ajoute un systâ”œÂ»â”¬â”â”¬Â¢me de taxes râ”œÂ»â”¬â”â”¬Â¢aliste â”œÂ»â”¬â”â”¬Â¢ votre ferme.
 
-Fonctionnalit├»┬┐┬¢s :
-├»┬┐┬¢ D├»┬┐┬¢ductions fiscales quotidiennes bas├»┬┐┬¢es sur le solde de la ferme
-├»┬┐┬¢ Remboursements d'imp├»┬┐┬¢ts mensuels (pourcentage des taxes pay├»┬┐┬¢es)
-├»┬┐┬¢ Trois niveaux de taux d'imposition : Faible (1%), Moyen (2%), ├»┬┐┬¢lev├»┬┐┬¢ (3%)
-├»┬┐┬¢ Seuil de solde minimum configurable
-├»┬┐┬¢ Suivi de l'historique et des statistiques fiscales
-├»┬┐┬¢ Notifications professionnelles en jeu
-├»┬┐┬¢ Enti├»┬┐┬¢rement configurable via des commandes console
-├»┬┐┬¢ Compatible multijoueur
-├»┬┐┬¢ Param├»┬┐┬¢tres enregistr├»┬┐┬¢s par partie
-├»┬┐┬¢ Tapez 'tax' dans la console pour les commandes
+Fonctionnalitâ”œÂ»â”¬â”â”¬Â¢s :
+â”œÂ»â”¬â”â”¬Â¢ Dâ”œÂ»â”¬â”â”¬Â¢ductions fiscales quotidiennes basâ”œÂ»â”¬â”â”¬Â¢es sur le solde de la ferme
+â”œÂ»â”¬â”â”¬Â¢ Remboursements d'impâ”œÂ»â”¬â”â”¬Â¢ts mensuels (pourcentage des taxes payâ”œÂ»â”¬â”â”¬Â¢es)
+â”œÂ»â”¬â”â”¬Â¢ Trois niveaux de taux d'imposition : Faible (1%), Moyen (2%), â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢ (3%)
+â”œÂ»â”¬â”â”¬Â¢ Seuil de solde minimum configurable
+â”œÂ»â”¬â”â”¬Â¢ Suivi de l'historique et des statistiques fiscales
+â”œÂ»â”¬â”â”¬Â¢ Notifications professionnelles en jeu
+â”œÂ»â”¬â”â”¬Â¢ Entiâ”œÂ»â”¬â”â”¬Â¢rement configurable via des commandes console
+â”œÂ»â”¬â”â”¬Â¢ Compatible multijoueur
+â”œÂ»â”¬â”â”¬Â¢ Paramâ”œÂ»â”¬â”â”¬Â¢tres enregistrâ”œÂ»â”¬â”â”¬Â¢s par partie
+â”œÂ»â”¬â”â”¬Â¢ Tapez 'tax' dans la console pour les commandes
 ]]></fr>
 
         <es><![CDATA[
-A├»┬┐┬¢ade un sistema de impuestos realista a tu granja.
+Aâ”œÂ»â”¬â”â”¬Â¢ade un sistema de impuestos realista a tu granja.
 
-Caracter├»┬┐┬¢sticas:
-├»┬┐┬¢ Deducciones fiscales diarias basadas en el saldo de la granja
-├»┬┐┬¢ Devoluciones de impuestos mensuales (porcentaje de impuestos pagados)
-├»┬┐┬¢ Tres niveles de tasa impositiva: Baja (1%), Media (2%), Alta (3%)
-├»┬┐┬¢ Umbral de saldo m├»┬┐┬¢nimo configurable
-├»┬┐┬¢ Seguimiento de historial y estad├»┬┐┬¢sticas fiscales
-├»┬┐┬¢ Notificaciones profesionales en el juego
-├»┬┐┬¢ Totalmente configurable mediante comandos de consola
-├»┬┐┬¢ Compatible con multijugador
-├»┬┐┬¢ Configuraciones guardadas por partida
-├»┬┐┬¢ Escribe 'tax' en la consola para comandos
+Caracterâ”œÂ»â”¬â”â”¬Â¢sticas:
+â”œÂ»â”¬â”â”¬Â¢ Deducciones fiscales diarias basadas en el saldo de la granja
+â”œÂ»â”¬â”â”¬Â¢ Devoluciones de impuestos mensuales (porcentaje de impuestos pagados)
+â”œÂ»â”¬â”â”¬Â¢ Tres niveles de tasa impositiva: Baja (1%), Media (2%), Alta (3%)
+â”œÂ»â”¬â”â”¬Â¢ Umbral de saldo mâ”œÂ»â”¬â”â”¬Â¢nimo configurable
+â”œÂ»â”¬â”â”¬Â¢ Seguimiento de historial y estadâ”œÂ»â”¬â”â”¬Â¢sticas fiscales
+â”œÂ»â”¬â”â”¬Â¢ Notificaciones profesionales en el juego
+â”œÂ»â”¬â”â”¬Â¢ Totalmente configurable mediante comandos de consola
+â”œÂ»â”¬â”â”¬Â¢ Compatible con multijugador
+â”œÂ»â”¬â”â”¬Â¢ Configuraciones guardadas por partida
+â”œÂ»â”¬â”â”¬Â¢ Escribe 'tax' en la consola para comandos
 ]]></es>
 
         <it><![CDATA[
 Aggiunge un sistema fiscale realistico alla tua fattoria.
 
 Caratteristiche:
-├»┬┐┬¢ Detrazioni fiscali giornaliere basate sul saldo della fattoria
-├»┬┐┬¢ Restituzioni fiscali mensili (percentuale delle tasse pagate)
-├»┬┐┬¢ Tre livelli di aliquota fiscale: Bassa (1%), Media (2%), Alta (3%)
-├»┬┐┬¢ Soglia di saldo minimo configurabile
-├»┬┐┬¢ Monitoraggio della cronologia e delle statistiche fiscali
-├»┬┐┬¢ Notifiche professionali in gioco
-├»┬┐┬¢ Completamente configurabile tramite comandi console
-├»┬┐┬¢ Compatibile con il multiplayer
-├»┬┐┬¢ Impostazioni salvate per partita
-├»┬┐┬¢ Digita 'tax' nella console per i comandi
+â”œÂ»â”¬â”â”¬Â¢ Detrazioni fiscali giornaliere basate sul saldo della fattoria
+â”œÂ»â”¬â”â”¬Â¢ Restituzioni fiscali mensili (percentuale delle tasse pagate)
+â”œÂ»â”¬â”â”¬Â¢ Tre livelli di aliquota fiscale: Bassa (1%), Media (2%), Alta (3%)
+â”œÂ»â”¬â”â”¬Â¢ Soglia di saldo minimo configurabile
+â”œÂ»â”¬â”â”¬Â¢ Monitoraggio della cronologia e delle statistiche fiscali
+â”œÂ»â”¬â”â”¬Â¢ Notifiche professionali in gioco
+â”œÂ»â”¬â”â”¬Â¢ Completamente configurabile tramite comandi console
+â”œÂ»â”¬â”â”¬Â¢ Compatibile con il multiplayer
+â”œÂ»â”¬â”â”¬Â¢ Impostazioni salvate per partita
+â”œÂ»â”¬â”â”¬Â¢ Digita 'tax' nella console per i comandi
 ]]></it>
 
         <pl><![CDATA[
 Dodaje realistyczny system podatkowy do Twojej farmy.
 
 Funkcje:
-├»┬┐┬¢ Codzienne odliczenia podatkowe na podstawie salda farmy
-├»┬┐┬¢ Miesieczne zwroty podatk├»┬┐┬¢w (procent zaplaconych podatk├»┬┐┬¢w)
-├»┬┐┬¢ Trzy poziomy stawek podatkowych: Niski (1%), Sredni (2%), Wysoki (3%)
-├»┬┐┬¢ Konfigurowalny pr├»┬┐┬¢g minimalnego salda
-├»┬┐┬¢ Sledzenie historii i statystyk podatkowych
-├»┬┐┬¢ Profesjonalne powiadomienia w grze
-├»┬┐┬¢ W pelni konfigurowalne za pomoca komend konsoli
-├»┬┐┬¢ Zgodny z trybem wieloosobowym
-├»┬┐┬¢ Ustawienia zapisywane per zapis gry
-├»┬┐┬¢ Wpisz 'tax' w konsoli dla komend
+â”œÂ»â”¬â”â”¬Â¢ Codzienne odliczenia podatkowe na podstawie salda farmy
+â”œÂ»â”¬â”â”¬Â¢ Miesieczne zwroty podatkâ”œÂ»â”¬â”â”¬Â¢w (procent zaplaconych podatkâ”œÂ»â”¬â”â”¬Â¢w)
+â”œÂ»â”¬â”â”¬Â¢ Trzy poziomy stawek podatkowych: Niski (1%), Sredni (2%), Wysoki (3%)
+â”œÂ»â”¬â”â”¬Â¢ Konfigurowalny prâ”œÂ»â”¬â”â”¬Â¢g minimalnego salda
+â”œÂ»â”¬â”â”¬Â¢ Sledzenie historii i statystyk podatkowych
+â”œÂ»â”¬â”â”¬Â¢ Profesjonalne powiadomienia w grze
+â”œÂ»â”¬â”â”¬Â¢ W pelni konfigurowalne za pomoca komend konsoli
+â”œÂ»â”¬â”â”¬Â¢ Zgodny z trybem wieloosobowym
+â”œÂ»â”¬â”â”¬Â¢ Ustawienia zapisywane per zapis gry
+â”œÂ»â”¬â”â”¬Â¢ Wpisz 'tax' w konsoli dla komend
 ]]></pl>
     </description>
 
@@ -168,8 +168,8 @@ Funkcje:
         </text>
         <text name="tm_enabled_long">
             <en><![CDATA[Enable or disable daily tax deductions and monthly returns]]></en>
-            <de><![CDATA[T├»┬┐┬¢gliche Steuerabz├»┬┐┬¢ge und monatliche R├»┬┐┬¢ckerstattungen ein-/ausschalten]]></de>
-            <fr><![CDATA[Activer ou d├»┬┐┬¢sactiver les d├»┬┐┬¢ductions fiscales quotidiennes et les remboursements mensuels]]></fr>
+            <de><![CDATA[Tâ”œÂ»â”¬â”â”¬Â¢gliche Steuerabzâ”œÂ»â”¬â”â”¬Â¢ge und monatliche Râ”œÂ»â”¬â”â”¬Â¢ckerstattungen ein-/ausschalten]]></de>
+            <fr><![CDATA[Activer ou dâ”œÂ»â”¬â”â”¬Â¢sactiver les dâ”œÂ»â”¬â”â”¬Â¢ductions fiscales quotidiennes et les remboursements mensuels]]></fr>
             <es><![CDATA[Activar o desactivar las deducciones fiscales diarias y las devoluciones mensuales]]></es>
             <it><![CDATA[Attiva o disattiva le detrazioni fiscali giornaliere e i rimborsi mensili]]></it>
             <pl><![CDATA[Wlacz lub wylacz codzienne odliczenia podatkowe i miesieczne zwroty]]></pl>
@@ -178,7 +178,7 @@ Funkcje:
             <cz>[EN] <![CDATA[Enable or disable daily tax deductions and monthly returns]]></cz>
             <br>[EN] <![CDATA[Enable or disable daily tax deductions and monthly returns]]></br>
             <ru>[EN] <![CDATA[Enable or disable daily tax deductions and monthly returns]]></ru>
-            <da><![CDATA[Aktiv├»┬┐┬¢r eller deaktiver daglige skattefradrag og m├»┬┐┬¢nedlige skatterefusioner]]></da>
+            <da><![CDATA[Aktivâ”œÂ»â”¬â”â”¬Â¢r eller deaktiver daglige skattefradrag og mâ”œÂ»â”¬â”â”¬Â¢nedlige skatterefusioner]]></da>
         </text>
 
         <!-- Tax Rate -->
@@ -198,8 +198,8 @@ Funkcje:
         </text>
         <text name="tm_taxrate_long">
             <en><![CDATA[Daily tax rate applied to your farm balance: Low=1%, Medium=2%, High=3%]]></en>
-            <de><![CDATA[T├»┬┐┬¢glicher Steuersatz auf Ihr Farmguthaben: Niedrig=1%, Mittel=2%, Hoch=3%]]></de>
-            <fr><![CDATA[Taux d'imposition quotidien appliqu├»┬┐┬¢ ├»┬┐┬¢ votre solde: Faible=1%, Moyen=2%, ├»┬┐┬¢lev├»┬┐┬¢=3%]]></fr>
+            <de><![CDATA[Tâ”œÂ»â”¬â”â”¬Â¢glicher Steuersatz auf Ihr Farmguthaben: Niedrig=1%, Mittel=2%, Hoch=3%]]></de>
+            <fr><![CDATA[Taux d'imposition quotidien appliquâ”œÂ»â”¬â”â”¬Â¢ â”œÂ»â”¬â”â”¬Â¢ votre solde: Faible=1%, Moyen=2%, â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢=3%]]></fr>
             <es><![CDATA[Tasa impositiva diaria sobre el saldo de tu granja: Baja=1%, Media=2%, Alta=3%]]></es>
             <it><![CDATA[Aliquota fiscale giornaliera sul saldo della fattoria: Bassa=1%, Media=2%, Alta=3%]]></it>
             <pl><![CDATA[Dzienna stawka podatkowa od salda farmy: Niska=1%, Srednia=2%, Wysoka=3%]]></pl>
@@ -208,7 +208,7 @@ Funkcje:
             <cz>[EN] <![CDATA[Daily tax rate applied to your farm balance: Low=1%, Medium=2%, High=3%]]></cz>
             <br>[EN] <![CDATA[Daily tax rate applied to your farm balance: Low=1%, Medium=2%, High=3%]]></br>
             <ru>[EN] <![CDATA[Daily tax rate applied to your farm balance: Low=1%, Medium=2%, High=3%]]></ru>
-            <da><![CDATA[Daglig skattesats anvendt p├»┬┐┬¢ din g├»┬┐┬¢rds saldo: Lav=1 %, Mellem=2 %, H├»┬┐┬¢j=3 %]]></da>
+            <da><![CDATA[Daglig skattesats anvendt pâ”œÂ»â”¬â”â”¬Â¢ din gâ”œÂ»â”¬â”â”¬Â¢rds saldo: Lav=1 %, Mellem=2 %, Hâ”œÂ»â”¬â”â”¬Â¢j=3 %]]></da>
         </text>
         <text name="tm_taxrate_1"><en><![CDATA[Low (1%)]]></en><de><![CDATA[Niedrig (1%)]]></de><fr><![CDATA[Faible (1%)]]></fr><es><![CDATA[Baja (1%)]]></es><it><![CDATA[Bassa (1%)]]></it><pl><![CDATA[Niska (1%)]]></pl><uk><![CDATA[?????? (1%)]]></uk>
             <cz>[EN] <![CDATA[Low (1%)]]></cz>
@@ -222,17 +222,17 @@ Funkcje:
             <ru>[EN] <![CDATA[Medium (2%)]]></ru>
             <da><![CDATA[Mellem (2 %)]]></da>
         </text>
-        <text name="tm_taxrate_3"><en><![CDATA[High (3%)]]></en><de><![CDATA[Hoch (3%)]]></de><fr><![CDATA[├»┬┐┬¢lev├»┬┐┬¢ (3%)]]></fr><es><![CDATA[Alta (3%)]]></es><it><![CDATA[Alta (3%)]]></it><pl><![CDATA[Wysoka (3%)]]></pl><uk><![CDATA[?????? (3%)]]></uk>
+        <text name="tm_taxrate_3"><en><![CDATA[High (3%)]]></en><de><![CDATA[Hoch (3%)]]></de><fr><![CDATA[â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢ (3%)]]></fr><es><![CDATA[Alta (3%)]]></es><it><![CDATA[Alta (3%)]]></it><pl><![CDATA[Wysoka (3%)]]></pl><uk><![CDATA[?????? (3%)]]></uk>
             <cz>[EN] <![CDATA[High (3%)]]></cz>
             <br>[EN] <![CDATA[High (3%)]]></br>
             <ru>[EN] <![CDATA[High (3%)]]></ru>
-            <da><![CDATA[H├»┬┐┬¢j (3 %)]]></da>
+            <da><![CDATA[Hâ”œÂ»â”¬â”â”¬Â¢j (3 %)]]></da>
         </text>
 
         <!-- Annual Tax Rate -->
         <text name="tm_annualrate_short">
             <en><![CDATA[Annual Tax Rate]]></en>
-            <de><![CDATA[J├»┬┐┬¢hrlicher Steuersatz]]></de>
+            <de><![CDATA[Jâ”œÂ»â”¬â”â”¬Â¢hrlicher Steuersatz]]></de>
             <fr><![CDATA[Taux d'imposition annuel]]></fr>
             <es><![CDATA[Tasa impositiva anual]]></es>
             <it><![CDATA[Aliquota fiscale annuale]]></it>
@@ -242,21 +242,21 @@ Funkcje:
             <cz>[EN] <![CDATA[Annual Tax Rate]]></cz>
             <br>[EN] <![CDATA[Annual Tax Rate]]></br>
             <ru>[EN] <![CDATA[Annual Tax Rate]]></ru>
-            <da><![CDATA[├»┬┐┬¢rlig skattesats]]></da>
+            <da><![CDATA[â”œÂ»â”¬â”â”¬Â¢rlig skattesats]]></da>
         </text>
         <text name="tm_annualrate_long">
             <en><![CDATA[Percentage of accumulated taxes paid each March: Low=2%, Medium=5%, High=10%]]></en>
-            <de><![CDATA[Prozentsatz der angesammelten Steuern, der jeden M├»┬┐┬¢rz gezahlt wird: Niedrig=2%, Mittel=5%, Hoch=10%]]></de>
-            <fr><![CDATA[Pourcentage des taxes accumul├»┬┐┬¢es pay├»┬┐┬¢es chaque mars: Faible=2%, Moyen=5%, ├»┬┐┬¢lev├»┬┐┬¢=10%]]></fr>
+            <de><![CDATA[Prozentsatz der angesammelten Steuern, der jeden Mâ”œÂ»â”¬â”â”¬Â¢rz gezahlt wird: Niedrig=2%, Mittel=5%, Hoch=10%]]></de>
+            <fr><![CDATA[Pourcentage des taxes accumulâ”œÂ»â”¬â”â”¬Â¢es payâ”œÂ»â”¬â”â”¬Â¢es chaque mars: Faible=2%, Moyen=5%, â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢=10%]]></fr>
             <es><![CDATA[Porcentaje de impuestos acumulados pagados cada marzo: Baja=2%, Media=5%, Alta=10%]]></es>
             <it><![CDATA[Percentuale delle tasse accumulate pagate ogni marzo: Bassa=2%, Media=5%, Alta=10%]]></it>
-            <pl><![CDATA[Procent zgromadzonych podatk├»┬┐┬¢w placonych kazdego marca: Niski=2%, Sredni=5%, Wysoki=10%]]></pl>
+            <pl><![CDATA[Procent zgromadzonych podatkâ”œÂ»â”¬â”â”¬Â¢w placonych kazdego marca: Niski=2%, Sredni=5%, Wysoki=10%]]></pl>
             <uk><![CDATA[???????? ??????????? ????????, ?? ??????????? ??????? ???????: ???????=2%, ????????=5%, ???????=10%]]></uk>
         
             <cz>[EN] <![CDATA[Percentage of accumulated taxes paid each March: Low=2%, Medium=5%, High=10%]]></cz>
             <br>[EN] <![CDATA[Percentage of accumulated taxes paid each March: Low=2%, Medium=5%, High=10%]]></br>
             <ru>[EN] <![CDATA[Percentage of accumulated taxes paid each March: Low=2%, Medium=5%, High=10%]]></ru>
-            <da><![CDATA[Procentdel af de akkumulerede skatter, der udbetales hver marts: Lav=2 %, Mellem=5 %, H├»┬┐┬¢j=10 %]]></da>
+            <da><![CDATA[Procentdel af de akkumulerede skatter, der udbetales hver marts: Lav=2 %, Mellem=5 %, Hâ”œÂ»â”¬â”â”¬Â¢j=10 %]]></da>
         </text>
         <text name="tm_annualrate_1"><en><![CDATA[Low (2%)]]></en><de><![CDATA[Niedrig (2%)]]></de><fr><![CDATA[Faible (2%)]]></fr><es><![CDATA[Baja (2%)]]></es><it><![CDATA[Bassa (2%)]]></it><pl><![CDATA[Niski (2%)]]></pl><uk><![CDATA[??????? (2%)]]></uk>
             <cz>[EN] <![CDATA[Low (2%)]]></cz>
@@ -270,19 +270,19 @@ Funkcje:
             <ru>[EN] <![CDATA[Medium (5%)]]></ru>
             <da><![CDATA[Mellem (5 %)]]></da>
         </text>
-        <text name="tm_annualrate_3"><en><![CDATA[High (10%)]]></en><de><![CDATA[Hoch (10%)]]></de><fr><![CDATA[├»┬┐┬¢lev├»┬┐┬¢ (10%)]]></fr><es><![CDATA[Alta (10%)]]></es><it><![CDATA[Alta (10%)]]></it><pl><![CDATA[Wysoki (10%)]]></pl><uk><![CDATA[??????? (10%)]]></uk>
+        <text name="tm_annualrate_3"><en><![CDATA[High (10%)]]></en><de><![CDATA[Hoch (10%)]]></de><fr><![CDATA[â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢ (10%)]]></fr><es><![CDATA[Alta (10%)]]></es><it><![CDATA[Alta (10%)]]></it><pl><![CDATA[Wysoki (10%)]]></pl><uk><![CDATA[??????? (10%)]]></uk>
             <cz>[EN] <![CDATA[High (10%)]]></cz>
             <br>[EN] <![CDATA[High (10%)]]></br>
             <ru>[EN] <![CDATA[High (10%)]]></ru>
-            <da><![CDATA[H├»┬┐┬¢j (10 %)]]></da>
+            <da><![CDATA[Hâ”œÂ»â”¬â”â”¬Â¢j (10 %)]]></da>
         </text>
 
         <!-- Return Percentage (kept for save compatibility) -->
         <text name="tm_return_short">
             <en><![CDATA[Tax Return %]]></en>
-            <de><![CDATA[Steuerr├»┬┐┬¢ckerstattung %]]></de>
+            <de><![CDATA[Steuerrâ”œÂ»â”¬â”â”¬Â¢ckerstattung %]]></de>
             <fr><![CDATA[Remboursement fiscal %]]></fr>
-            <es><![CDATA[% Devoluci├»┬┐┬¢n de impuestos]]></es>
+            <es><![CDATA[% Devoluciâ”œÂ»â”¬â”â”¬Â¢n de impuestos]]></es>
             <it><![CDATA[% Rimborso fiscale]]></it>
             <pl><![CDATA[% Zwrotu podatku]]></pl>
             <uk><![CDATA[% ?????????? ???????]]></uk>
@@ -294,17 +294,17 @@ Funkcje:
         </text>
         <text name="tm_return_long">
             <en><![CDATA[Percentage of monthly taxes returned at the start of each new month: Low=10%, Medium=20%, High=30%]]></en>
-            <de><![CDATA[Prozentsatz der monatlichen Steuern, der zur├»┬┐┬¢ckerstattet wird: Niedrig=10%, Mittel=20%, Hoch=30%]]></de>
-            <fr><![CDATA[Pourcentage des taxes mensuelles rembours├»┬┐┬¢es: Faible=10%, Moyen=20%, ├»┬┐┬¢lev├»┬┐┬¢=30%]]></fr>
+            <de><![CDATA[Prozentsatz der monatlichen Steuern, der zurâ”œÂ»â”¬â”â”¬Â¢ckerstattet wird: Niedrig=10%, Mittel=20%, Hoch=30%]]></de>
+            <fr><![CDATA[Pourcentage des taxes mensuelles remboursâ”œÂ»â”¬â”â”¬Â¢es: Faible=10%, Moyen=20%, â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢=30%]]></fr>
             <es><![CDATA[Porcentaje de impuestos mensuales devueltos: Baja=10%, Media=20%, Alta=30%]]></es>
             <it><![CDATA[Percentuale delle tasse mensili rimborsate: Bassa=10%, Media=20%, Alta=30%]]></it>
-            <pl><![CDATA[Procent miesiecznych podatk├»┬┐┬¢w zwracanych: Niski=10%, Sredni=20%, Wysoki=30%]]></pl>
+            <pl><![CDATA[Procent miesiecznych podatkâ”œÂ»â”¬â”â”¬Â¢w zwracanych: Niski=10%, Sredni=20%, Wysoki=30%]]></pl>
             <uk><![CDATA[???????? ???????? ????????, ?? ???????????? ?? ??????? ??????: ???????=10%, ????????=20%, ???????=30%]]></uk>
         
             <cz>[EN] <![CDATA[Percentage of monthly taxes returned at the start of each new month: Low=10%, Medium=20%, High=30%]]></cz>
             <br>[EN] <![CDATA[Percentage of monthly taxes returned at the start of each new month: Low=10%, Medium=20%, High=30%]]></br>
             <ru>[EN] <![CDATA[Percentage of monthly taxes returned at the start of each new month: Low=10%, Medium=20%, High=30%]]></ru>
-            <da><![CDATA[Procentdel af de m├»┬┐┬¢nedlige skatter, der tilbagebetales ved starten af hver ny m├»┬┐┬¢ned: Lav=10 %, Mellem=20 %, H├»┬┐┬¢j=30 %]]></da>
+            <da><![CDATA[Procentdel af de mâ”œÂ»â”¬â”â”¬Â¢nedlige skatter, der tilbagebetales ved starten af hver ny mâ”œÂ»â”¬â”â”¬Â¢ned: Lav=10 %, Mellem=20 %, Hâ”œÂ»â”¬â”â”¬Â¢j=30 %]]></da>
         </text>
         <text name="tm_return_1"><en><![CDATA[Low (10%)]]></en><de><![CDATA[Niedrig (10%)]]></de><fr><![CDATA[Faible (10%)]]></fr><es><![CDATA[Baja (10%)]]></es><it><![CDATA[Bassa (10%)]]></it><pl><![CDATA[Niski (10%)]]></pl><uk><![CDATA[??????? (10%)]]></uk>
             <cz>[EN] <![CDATA[Low (10%)]]></cz>
@@ -318,11 +318,11 @@ Funkcje:
             <ru>[EN] <![CDATA[Medium (20%)]]></ru>
             <da><![CDATA[Mellem (20 %)]]></da>
         </text>
-        <text name="tm_return_3"><en><![CDATA[High (30%)]]></en><de><![CDATA[Hoch (30%)]]></de><fr><![CDATA[├»┬┐┬¢lev├»┬┐┬¢ (30%)]]></fr><es><![CDATA[Alta (30%)]]></es><it><![CDATA[Alta (30%)]]></it><pl><![CDATA[Wysoki (30%)]]></pl><uk><![CDATA[??????? (30%)]]></uk>
+        <text name="tm_return_3"><en><![CDATA[High (30%)]]></en><de><![CDATA[Hoch (30%)]]></de><fr><![CDATA[â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢ (30%)]]></fr><es><![CDATA[Alta (30%)]]></es><it><![CDATA[Alta (30%)]]></it><pl><![CDATA[Wysoki (30%)]]></pl><uk><![CDATA[??????? (30%)]]></uk>
             <cz>[EN] <![CDATA[High (30%)]]></cz>
             <br>[EN] <![CDATA[High (30%)]]></br>
             <ru>[EN] <![CDATA[High (30%)]]></ru>
-            <da><![CDATA[H├»┬┐┬¢j (30 %)]]></da>
+            <da><![CDATA[Hâ”œÂ»â”¬â”â”¬Â¢j (30 %)]]></da>
         </text>
 
         <!-- Notifications -->
@@ -342,8 +342,8 @@ Funkcje:
         </text>
         <text name="tm_notifications_long">
             <en><![CDATA[Show in-game notifications when taxes are deducted or returns are paid]]></en>
-            <de><![CDATA[In-Game-Benachrichtigungen anzeigen, wenn Steuern abgezogen oder R├»┬┐┬¢ckerstattungen gezahlt werden]]></de>
-            <fr><![CDATA[Afficher les notifications en jeu lors des d├»┬┐┬¢ductions fiscales ou des remboursements]]></fr>
+            <de><![CDATA[In-Game-Benachrichtigungen anzeigen, wenn Steuern abgezogen oder Râ”œÂ»â”¬â”â”¬Â¢ckerstattungen gezahlt werden]]></de>
+            <fr><![CDATA[Afficher les notifications en jeu lors des dâ”œÂ»â”¬â”â”¬Â¢ductions fiscales ou des remboursements]]></fr>
             <es><![CDATA[Mostrar notificaciones en el juego cuando se deducen impuestos o se pagan devoluciones]]></es>
             <it><![CDATA[Mostra notifiche in gioco quando vengono detratte le tasse o pagati i rimborsi]]></it>
             <pl><![CDATA[Pokazuj powiadomienia w grze gdy podatki sa odliczane lub zwracane]]></pl>
@@ -352,7 +352,7 @@ Funkcje:
             <cz>[EN] <![CDATA[Show in-game notifications when taxes are deducted or returns are paid]]></cz>
             <br>[EN] <![CDATA[Show in-game notifications when taxes are deducted or returns are paid]]></br>
             <ru>[EN] <![CDATA[Show in-game notifications when taxes are deducted or returns are paid]]></ru>
-            <da><![CDATA[Vis notifikationer i spillet, n├»┬┐┬¢r skatter fratr├»┬┐┬¢kkes eller refusioner udbetales]]></da>
+            <da><![CDATA[Vis notifikationer i spillet, nâ”œÂ»â”¬â”â”¬Â¢r skatter fratrâ”œÂ»â”¬â”â”¬Â¢kkes eller refusioner udbetales]]></da>
         </text>
 
         <!-- Show HUD -->
@@ -372,17 +372,17 @@ Funkcje:
         </text>
         <text name="tm_show_hud_long">
             <en><![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with T key)]]></en>
-            <de><![CDATA[Tax-HUD mit aktuellem Steuersatz, Statistiken und letzten Aktivit├»┬┐┬¢ten anzeigen (mit T umschalten)]]></de>
-            <fr><![CDATA[Afficher l'HUD fiscal avec le taux actuel, les statistiques et l'activit├»┬┐┬¢ r├»┬┐┬¢cente (basculer avec T)]]></fr>
-            <es><![CDATA[Mostrar el HUD fiscal con la tasa actual, estad├»┬┐┬¢sticas y actividad reciente (alternar con T)]]></es>
-            <it><![CDATA[Mostra l'HUD fiscale con aliquota corrente, statistiche e attivit├»┬┐┬¢ recente (attiva/disattiva con T)]]></it>
+            <de><![CDATA[Tax-HUD mit aktuellem Steuersatz, Statistiken und letzten Aktivitâ”œÂ»â”¬â”â”¬Â¢ten anzeigen (mit T umschalten)]]></de>
+            <fr><![CDATA[Afficher l'HUD fiscal avec le taux actuel, les statistiques et l'activitâ”œÂ»â”¬â”â”¬Â¢ râ”œÂ»â”¬â”â”¬Â¢cente (basculer avec T)]]></fr>
+            <es><![CDATA[Mostrar el HUD fiscal con la tasa actual, estadâ”œÂ»â”¬â”â”¬Â¢sticas y actividad reciente (alternar con T)]]></es>
+            <it><![CDATA[Mostra l'HUD fiscale con aliquota corrente, statistiche e attivitâ”œÂ»â”¬â”â”¬Â¢ recente (attiva/disattiva con T)]]></it>
             <pl><![CDATA[Pokaz HUD podatkowy z biezaca stawka, statystykami i ostatnia aktywnoscia (przelacz klawiszem T)]]></pl>
             <uk><![CDATA[???????? HUD ???????? ? ???????? ???????, ??????????? ?? ??????????? ?????????? (?????????? ???????? T)]]></uk>
         
             <cz>[EN] <![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with T key)]]></cz>
             <br>[EN] <![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with T key)]]></br>
             <ru>[EN] <![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with T key)]]></ru>
-            <da><![CDATA[Vis skatte-HUD-overlayet med aktuel sats, statistik og seneste aktivitet (sl├»┬┐┬¢ til/fra med T-tasten)]]></da>
+            <da><![CDATA[Vis skatte-HUD-overlayet med aktuel sats, statistik og seneste aktivitet (slâ”œÂ»â”¬â”â”¬Â¢ til/fra med T-tasten)]]></da>
         </text>
 
         <!-- HUD toggle key binding display name -->
@@ -397,7 +397,7 @@ Funkcje:
             <cz>[EN] <![CDATA[Toggle Tax HUD]]></cz>
             <br>[EN] <![CDATA[Toggle Tax HUD]]></br>
             <ru>[EN] <![CDATA[Toggle Tax HUD]]></ru>
-            <da><![CDATA[Sl├»┬┐┬¢ skatte-HUD til/fra]]></da>
+            <da><![CDATA[Slâ”œÂ»â”¬â”â”¬Â¢ skatte-HUD til/fra]]></da>
         </text>
         <text name="input_TM_HUD_DRAG">
             <en>Tax HUD Edit Mode</en>
@@ -821,32 +821,32 @@ Funkcje:
             <vi><![CDATA[[EN] Tax posture glance: on/off, bill, March, balance share, countdown, lifetime paid, ledger summary.]]></vi>
         </text>
         <text name="tax_rf_pda_hint_rates">
-            <en><![CDATA[Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></en>
-            <de><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></de>
-            <fr><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></fr>
-            <pl><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></pl>
-            <es><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></es>
-            <it><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></it>
-            <cz><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></cz>
-            <br><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></br>
-            <uk><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></uk>
-            <ru><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></ru>
-            <da><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></da>
-            <ct><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></ct>
-            <ea><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></ea>
-            <fc><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></fc>
-            <fi><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></fi>
-            <hu><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></hu>
-            <id><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></id>
-            <jp><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></jp>
-            <kr><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></kr>
-            <nl><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></nl>
-            <no><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></no>
-            <pt><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></pt>
-            <ro><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></ro>
-            <sv><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></sv>
-            <tr><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></tr>
-            <vi><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></vi>
+            <en><![CDATA[Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></en>
+            <de><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></de>
+            <fr><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></fr>
+            <pl><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></pl>
+            <es><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></es>
+            <it><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></it>
+            <cz><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></cz>
+            <br><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></br>
+            <uk><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></uk>
+            <ru><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></ru>
+            <da><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></da>
+            <ct><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></ct>
+            <ea><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></ea>
+            <fc><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></fc>
+            <fi><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></fi>
+            <hu><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></hu>
+            <id><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></id>
+            <jp><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></jp>
+            <kr><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></kr>
+            <nl><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></nl>
+            <no><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></no>
+            <pt><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></pt>
+            <ro><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></ro>
+            <sv><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></sv>
+            <tr><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></tr>
+            <vi><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></vi>
         </text>
         <text name="tax_rf_pda_lbl_min_balance">
             <en><![CDATA[Min balance]]></en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -20,96 +20,96 @@
 Adds realistic tax system to your farm.
 
 Features:
-â”œÂ»â”¬â”â”¬Â¢ Daily tax deductions based on farm balance
-â”œÂ»â”¬â”â”¬Â¢ Monthly tax returns (percentage of taxes paid)
-â”œÂ»â”¬â”â”¬Â¢ Three tax rate levels: Low (1%), Medium (2%), High (3%)
-â”œÂ»â”¬â”â”¬Â¢ Configurable minimum balance threshold
-â”œÂ»â”¬â”â”¬Â¢ Tax history and statistics tracking
-â”œÂ»â”¬â”â”¬Â¢ Professional in-game notifications
-â”œÂ»â”¬â”â”¬Â¢ Fully configurable via console commands
-â”œÂ»â”¬â”â”¬Â¢ Multiplayer compatible
-â”œÂ»â”¬â”â”¬Â¢ Settings saved per savegame
-â”œÂ»â”¬â”â”¬Â¢ Type 'tax' in console for commands
+├»┬┐┬¢ Daily tax deductions based on farm balance
+├»┬┐┬¢ Monthly tax returns (percentage of taxes paid)
+├»┬┐┬¢ Three tax rate levels: Low (1%), Medium (2%), High (3%)
+├»┬┐┬¢ Configurable minimum balance threshold
+├»┬┐┬¢ Tax history and statistics tracking
+├»┬┐┬¢ Professional in-game notifications
+├»┬┐┬¢ Fully configurable via console commands
+├»┬┐┬¢ Multiplayer compatible
+├»┬┐┬¢ Settings saved per savegame
+├»┬┐┬¢ Type 'tax' in console for commands
 ]]></en>
 
         <de><![CDATA[
-Fâ”œÂ»â”¬â”â”¬Â¢gt ein realistisches Steuersystem zu Ihrer Farm hinzu.
+F├»┬┐┬¢gt ein realistisches Steuersystem zu Ihrer Farm hinzu.
 
 Funktionen:
-â”œÂ»â”¬â”â”¬Â¢ Tâ”œÂ»â”¬â”â”¬Â¢gliche Steuerabzâ”œÂ»â”¬â”â”¬Â¢ge basierend auf dem Farmguthaben
-â”œÂ»â”¬â”â”¬Â¢ Monatliche Steuerrâ”œÂ»â”¬â”â”¬Â¢ckzahlungen (Prozentsatz der gezahlten Steuern)
-â”œÂ»â”¬â”â”¬Â¢ Drei Steuersatzstufen: Niedrig (1%), Mittel (2%), Hoch (3%)
-â”œÂ»â”¬â”â”¬Â¢ Konfigurierbare Mindestguthabenschwelle
-â”œÂ»â”¬â”â”¬Â¢ Steuerverlauf und Statistikverfolgung
-â”œÂ»â”¬â”â”¬Â¢ Professionelle In-Game-Benachrichtigungen
-â”œÂ»â”¬â”â”¬Â¢ Vollstâ”œÂ»â”¬â”â”¬Â¢ndig â”œÂ»â”¬â”â”¬Â¢ber Konsolenbefehle konfigurierbar
-â”œÂ»â”¬â”â”¬Â¢ Multiplayer-kompatibel
-â”œÂ»â”¬â”â”¬Â¢ Einstellungen pro Spielstand gespeichert
-â”œÂ»â”¬â”â”¬Â¢ Geben Sie 'tax' in der Konsole fâ”œÂ»â”¬â”â”¬Â¢r Befehle ein
+├»┬┐┬¢ T├»┬┐┬¢gliche Steuerabz├»┬┐┬¢ge basierend auf dem Farmguthaben
+├»┬┐┬¢ Monatliche Steuerr├»┬┐┬¢ckzahlungen (Prozentsatz der gezahlten Steuern)
+├»┬┐┬¢ Drei Steuersatzstufen: Niedrig (1%), Mittel (2%), Hoch (3%)
+├»┬┐┬¢ Konfigurierbare Mindestguthabenschwelle
+├»┬┐┬¢ Steuerverlauf und Statistikverfolgung
+├»┬┐┬¢ Professionelle In-Game-Benachrichtigungen
+├»┬┐┬¢ Vollst├»┬┐┬¢ndig ├»┬┐┬¢ber Konsolenbefehle konfigurierbar
+├»┬┐┬¢ Multiplayer-kompatibel
+├»┬┐┬¢ Einstellungen pro Spielstand gespeichert
+├»┬┐┬¢ Geben Sie 'tax' in der Konsole f├»┬┐┬¢r Befehle ein
 ]]></de>
 
         <fr><![CDATA[
-Ajoute un systâ”œÂ»â”¬â”â”¬Â¢me de taxes râ”œÂ»â”¬â”â”¬Â¢aliste â”œÂ»â”¬â”â”¬Â¢ votre ferme.
+Ajoute un syst├»┬┐┬¢me de taxes r├»┬┐┬¢aliste ├»┬┐┬¢ votre ferme.
 
-Fonctionnalitâ”œÂ»â”¬â”â”¬Â¢s :
-â”œÂ»â”¬â”â”¬Â¢ Dâ”œÂ»â”¬â”â”¬Â¢ductions fiscales quotidiennes basâ”œÂ»â”¬â”â”¬Â¢es sur le solde de la ferme
-â”œÂ»â”¬â”â”¬Â¢ Remboursements d'impâ”œÂ»â”¬â”â”¬Â¢ts mensuels (pourcentage des taxes payâ”œÂ»â”¬â”â”¬Â¢es)
-â”œÂ»â”¬â”â”¬Â¢ Trois niveaux de taux d'imposition : Faible (1%), Moyen (2%), â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢ (3%)
-â”œÂ»â”¬â”â”¬Â¢ Seuil de solde minimum configurable
-â”œÂ»â”¬â”â”¬Â¢ Suivi de l'historique et des statistiques fiscales
-â”œÂ»â”¬â”â”¬Â¢ Notifications professionnelles en jeu
-â”œÂ»â”¬â”â”¬Â¢ Entiâ”œÂ»â”¬â”â”¬Â¢rement configurable via des commandes console
-â”œÂ»â”¬â”â”¬Â¢ Compatible multijoueur
-â”œÂ»â”¬â”â”¬Â¢ Paramâ”œÂ»â”¬â”â”¬Â¢tres enregistrâ”œÂ»â”¬â”â”¬Â¢s par partie
-â”œÂ»â”¬â”â”¬Â¢ Tapez 'tax' dans la console pour les commandes
+Fonctionnalit├»┬┐┬¢s :
+├»┬┐┬¢ D├»┬┐┬¢ductions fiscales quotidiennes bas├»┬┐┬¢es sur le solde de la ferme
+├»┬┐┬¢ Remboursements d'imp├»┬┐┬¢ts mensuels (pourcentage des taxes pay├»┬┐┬¢es)
+├»┬┐┬¢ Trois niveaux de taux d'imposition : Faible (1%), Moyen (2%), ├»┬┐┬¢lev├»┬┐┬¢ (3%)
+├»┬┐┬¢ Seuil de solde minimum configurable
+├»┬┐┬¢ Suivi de l'historique et des statistiques fiscales
+├»┬┐┬¢ Notifications professionnelles en jeu
+├»┬┐┬¢ Enti├»┬┐┬¢rement configurable via des commandes console
+├»┬┐┬¢ Compatible multijoueur
+├»┬┐┬¢ Param├»┬┐┬¢tres enregistr├»┬┐┬¢s par partie
+├»┬┐┬¢ Tapez 'tax' dans la console pour les commandes
 ]]></fr>
 
         <es><![CDATA[
-Aâ”œÂ»â”¬â”â”¬Â¢ade un sistema de impuestos realista a tu granja.
+A├»┬┐┬¢ade un sistema de impuestos realista a tu granja.
 
-Caracterâ”œÂ»â”¬â”â”¬Â¢sticas:
-â”œÂ»â”¬â”â”¬Â¢ Deducciones fiscales diarias basadas en el saldo de la granja
-â”œÂ»â”¬â”â”¬Â¢ Devoluciones de impuestos mensuales (porcentaje de impuestos pagados)
-â”œÂ»â”¬â”â”¬Â¢ Tres niveles de tasa impositiva: Baja (1%), Media (2%), Alta (3%)
-â”œÂ»â”¬â”â”¬Â¢ Umbral de saldo mâ”œÂ»â”¬â”â”¬Â¢nimo configurable
-â”œÂ»â”¬â”â”¬Â¢ Seguimiento de historial y estadâ”œÂ»â”¬â”â”¬Â¢sticas fiscales
-â”œÂ»â”¬â”â”¬Â¢ Notificaciones profesionales en el juego
-â”œÂ»â”¬â”â”¬Â¢ Totalmente configurable mediante comandos de consola
-â”œÂ»â”¬â”â”¬Â¢ Compatible con multijugador
-â”œÂ»â”¬â”â”¬Â¢ Configuraciones guardadas por partida
-â”œÂ»â”¬â”â”¬Â¢ Escribe 'tax' en la consola para comandos
+Caracter├»┬┐┬¢sticas:
+├»┬┐┬¢ Deducciones fiscales diarias basadas en el saldo de la granja
+├»┬┐┬¢ Devoluciones de impuestos mensuales (porcentaje de impuestos pagados)
+├»┬┐┬¢ Tres niveles de tasa impositiva: Baja (1%), Media (2%), Alta (3%)
+├»┬┐┬¢ Umbral de saldo m├»┬┐┬¢nimo configurable
+├»┬┐┬¢ Seguimiento de historial y estad├»┬┐┬¢sticas fiscales
+├»┬┐┬¢ Notificaciones profesionales en el juego
+├»┬┐┬¢ Totalmente configurable mediante comandos de consola
+├»┬┐┬¢ Compatible con multijugador
+├»┬┐┬¢ Configuraciones guardadas por partida
+├»┬┐┬¢ Escribe 'tax' en la consola para comandos
 ]]></es>
 
         <it><![CDATA[
 Aggiunge un sistema fiscale realistico alla tua fattoria.
 
 Caratteristiche:
-â”œÂ»â”¬â”â”¬Â¢ Detrazioni fiscali giornaliere basate sul saldo della fattoria
-â”œÂ»â”¬â”â”¬Â¢ Restituzioni fiscali mensili (percentuale delle tasse pagate)
-â”œÂ»â”¬â”â”¬Â¢ Tre livelli di aliquota fiscale: Bassa (1%), Media (2%), Alta (3%)
-â”œÂ»â”¬â”â”¬Â¢ Soglia di saldo minimo configurabile
-â”œÂ»â”¬â”â”¬Â¢ Monitoraggio della cronologia e delle statistiche fiscali
-â”œÂ»â”¬â”â”¬Â¢ Notifiche professionali in gioco
-â”œÂ»â”¬â”â”¬Â¢ Completamente configurabile tramite comandi console
-â”œÂ»â”¬â”â”¬Â¢ Compatibile con il multiplayer
-â”œÂ»â”¬â”â”¬Â¢ Impostazioni salvate per partita
-â”œÂ»â”¬â”â”¬Â¢ Digita 'tax' nella console per i comandi
+├»┬┐┬¢ Detrazioni fiscali giornaliere basate sul saldo della fattoria
+├»┬┐┬¢ Restituzioni fiscali mensili (percentuale delle tasse pagate)
+├»┬┐┬¢ Tre livelli di aliquota fiscale: Bassa (1%), Media (2%), Alta (3%)
+├»┬┐┬¢ Soglia di saldo minimo configurabile
+├»┬┐┬¢ Monitoraggio della cronologia e delle statistiche fiscali
+├»┬┐┬¢ Notifiche professionali in gioco
+├»┬┐┬¢ Completamente configurabile tramite comandi console
+├»┬┐┬¢ Compatibile con il multiplayer
+├»┬┐┬¢ Impostazioni salvate per partita
+├»┬┐┬¢ Digita 'tax' nella console per i comandi
 ]]></it>
 
         <pl><![CDATA[
 Dodaje realistyczny system podatkowy do Twojej farmy.
 
 Funkcje:
-â”œÂ»â”¬â”â”¬Â¢ Codzienne odliczenia podatkowe na podstawie salda farmy
-â”œÂ»â”¬â”â”¬Â¢ Miesieczne zwroty podatkâ”œÂ»â”¬â”â”¬Â¢w (procent zaplaconych podatkâ”œÂ»â”¬â”â”¬Â¢w)
-â”œÂ»â”¬â”â”¬Â¢ Trzy poziomy stawek podatkowych: Niski (1%), Sredni (2%), Wysoki (3%)
-â”œÂ»â”¬â”â”¬Â¢ Konfigurowalny prâ”œÂ»â”¬â”â”¬Â¢g minimalnego salda
-â”œÂ»â”¬â”â”¬Â¢ Sledzenie historii i statystyk podatkowych
-â”œÂ»â”¬â”â”¬Â¢ Profesjonalne powiadomienia w grze
-â”œÂ»â”¬â”â”¬Â¢ W pelni konfigurowalne za pomoca komend konsoli
-â”œÂ»â”¬â”â”¬Â¢ Zgodny z trybem wieloosobowym
-â”œÂ»â”¬â”â”¬Â¢ Ustawienia zapisywane per zapis gry
-â”œÂ»â”¬â”â”¬Â¢ Wpisz 'tax' w konsoli dla komend
+├»┬┐┬¢ Codzienne odliczenia podatkowe na podstawie salda farmy
+├»┬┐┬¢ Miesieczne zwroty podatk├»┬┐┬¢w (procent zaplaconych podatk├»┬┐┬¢w)
+├»┬┐┬¢ Trzy poziomy stawek podatkowych: Niski (1%), Sredni (2%), Wysoki (3%)
+├»┬┐┬¢ Konfigurowalny pr├»┬┐┬¢g minimalnego salda
+├»┬┐┬¢ Sledzenie historii i statystyk podatkowych
+├»┬┐┬¢ Profesjonalne powiadomienia w grze
+├»┬┐┬¢ W pelni konfigurowalne za pomoca komend konsoli
+├»┬┐┬¢ Zgodny z trybem wieloosobowym
+├»┬┐┬¢ Ustawienia zapisywane per zapis gry
+├»┬┐┬¢ Wpisz 'tax' w konsoli dla komend
 ]]></pl>
     </description>
 
@@ -168,8 +168,8 @@ Funkcje:
         </text>
         <text name="tm_enabled_long">
             <en><![CDATA[Enable or disable daily tax deductions and monthly returns]]></en>
-            <de><![CDATA[Tâ”œÂ»â”¬â”â”¬Â¢gliche Steuerabzâ”œÂ»â”¬â”â”¬Â¢ge und monatliche Râ”œÂ»â”¬â”â”¬Â¢ckerstattungen ein-/ausschalten]]></de>
-            <fr><![CDATA[Activer ou dâ”œÂ»â”¬â”â”¬Â¢sactiver les dâ”œÂ»â”¬â”â”¬Â¢ductions fiscales quotidiennes et les remboursements mensuels]]></fr>
+            <de><![CDATA[T├»┬┐┬¢gliche Steuerabz├»┬┐┬¢ge und monatliche R├»┬┐┬¢ckerstattungen ein-/ausschalten]]></de>
+            <fr><![CDATA[Activer ou d├»┬┐┬¢sactiver les d├»┬┐┬¢ductions fiscales quotidiennes et les remboursements mensuels]]></fr>
             <es><![CDATA[Activar o desactivar las deducciones fiscales diarias y las devoluciones mensuales]]></es>
             <it><![CDATA[Attiva o disattiva le detrazioni fiscali giornaliere e i rimborsi mensili]]></it>
             <pl><![CDATA[Wlacz lub wylacz codzienne odliczenia podatkowe i miesieczne zwroty]]></pl>
@@ -178,7 +178,7 @@ Funkcje:
             <cz>[EN] <![CDATA[Enable or disable daily tax deductions and monthly returns]]></cz>
             <br>[EN] <![CDATA[Enable or disable daily tax deductions and monthly returns]]></br>
             <ru>[EN] <![CDATA[Enable or disable daily tax deductions and monthly returns]]></ru>
-            <da><![CDATA[Aktivâ”œÂ»â”¬â”â”¬Â¢r eller deaktiver daglige skattefradrag og mâ”œÂ»â”¬â”â”¬Â¢nedlige skatterefusioner]]></da>
+            <da><![CDATA[Aktiv├»┬┐┬¢r eller deaktiver daglige skattefradrag og m├»┬┐┬¢nedlige skatterefusioner]]></da>
         </text>
 
         <!-- Tax Rate -->
@@ -198,8 +198,8 @@ Funkcje:
         </text>
         <text name="tm_taxrate_long">
             <en><![CDATA[Daily tax rate applied to your farm balance: Low=1%, Medium=2%, High=3%]]></en>
-            <de><![CDATA[Tâ”œÂ»â”¬â”â”¬Â¢glicher Steuersatz auf Ihr Farmguthaben: Niedrig=1%, Mittel=2%, Hoch=3%]]></de>
-            <fr><![CDATA[Taux d'imposition quotidien appliquâ”œÂ»â”¬â”â”¬Â¢ â”œÂ»â”¬â”â”¬Â¢ votre solde: Faible=1%, Moyen=2%, â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢=3%]]></fr>
+            <de><![CDATA[T├»┬┐┬¢glicher Steuersatz auf Ihr Farmguthaben: Niedrig=1%, Mittel=2%, Hoch=3%]]></de>
+            <fr><![CDATA[Taux d'imposition quotidien appliqu├»┬┐┬¢ ├»┬┐┬¢ votre solde: Faible=1%, Moyen=2%, ├»┬┐┬¢lev├»┬┐┬¢=3%]]></fr>
             <es><![CDATA[Tasa impositiva diaria sobre el saldo de tu granja: Baja=1%, Media=2%, Alta=3%]]></es>
             <it><![CDATA[Aliquota fiscale giornaliera sul saldo della fattoria: Bassa=1%, Media=2%, Alta=3%]]></it>
             <pl><![CDATA[Dzienna stawka podatkowa od salda farmy: Niska=1%, Srednia=2%, Wysoka=3%]]></pl>
@@ -208,7 +208,7 @@ Funkcje:
             <cz>[EN] <![CDATA[Daily tax rate applied to your farm balance: Low=1%, Medium=2%, High=3%]]></cz>
             <br>[EN] <![CDATA[Daily tax rate applied to your farm balance: Low=1%, Medium=2%, High=3%]]></br>
             <ru>[EN] <![CDATA[Daily tax rate applied to your farm balance: Low=1%, Medium=2%, High=3%]]></ru>
-            <da><![CDATA[Daglig skattesats anvendt pâ”œÂ»â”¬â”â”¬Â¢ din gâ”œÂ»â”¬â”â”¬Â¢rds saldo: Lav=1 %, Mellem=2 %, Hâ”œÂ»â”¬â”â”¬Â¢j=3 %]]></da>
+            <da><![CDATA[Daglig skattesats anvendt p├»┬┐┬¢ din g├»┬┐┬¢rds saldo: Lav=1 %, Mellem=2 %, H├»┬┐┬¢j=3 %]]></da>
         </text>
         <text name="tm_taxrate_1"><en><![CDATA[Low (1%)]]></en><de><![CDATA[Niedrig (1%)]]></de><fr><![CDATA[Faible (1%)]]></fr><es><![CDATA[Baja (1%)]]></es><it><![CDATA[Bassa (1%)]]></it><pl><![CDATA[Niska (1%)]]></pl><uk><![CDATA[?????? (1%)]]></uk>
             <cz>[EN] <![CDATA[Low (1%)]]></cz>
@@ -222,17 +222,17 @@ Funkcje:
             <ru>[EN] <![CDATA[Medium (2%)]]></ru>
             <da><![CDATA[Mellem (2 %)]]></da>
         </text>
-        <text name="tm_taxrate_3"><en><![CDATA[High (3%)]]></en><de><![CDATA[Hoch (3%)]]></de><fr><![CDATA[â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢ (3%)]]></fr><es><![CDATA[Alta (3%)]]></es><it><![CDATA[Alta (3%)]]></it><pl><![CDATA[Wysoka (3%)]]></pl><uk><![CDATA[?????? (3%)]]></uk>
+        <text name="tm_taxrate_3"><en><![CDATA[High (3%)]]></en><de><![CDATA[Hoch (3%)]]></de><fr><![CDATA[├»┬┐┬¢lev├»┬┐┬¢ (3%)]]></fr><es><![CDATA[Alta (3%)]]></es><it><![CDATA[Alta (3%)]]></it><pl><![CDATA[Wysoka (3%)]]></pl><uk><![CDATA[?????? (3%)]]></uk>
             <cz>[EN] <![CDATA[High (3%)]]></cz>
             <br>[EN] <![CDATA[High (3%)]]></br>
             <ru>[EN] <![CDATA[High (3%)]]></ru>
-            <da><![CDATA[Hâ”œÂ»â”¬â”â”¬Â¢j (3 %)]]></da>
+            <da><![CDATA[H├»┬┐┬¢j (3 %)]]></da>
         </text>
 
         <!-- Annual Tax Rate -->
         <text name="tm_annualrate_short">
             <en><![CDATA[Annual Tax Rate]]></en>
-            <de><![CDATA[Jâ”œÂ»â”¬â”â”¬Â¢hrlicher Steuersatz]]></de>
+            <de><![CDATA[J├»┬┐┬¢hrlicher Steuersatz]]></de>
             <fr><![CDATA[Taux d'imposition annuel]]></fr>
             <es><![CDATA[Tasa impositiva anual]]></es>
             <it><![CDATA[Aliquota fiscale annuale]]></it>
@@ -242,21 +242,21 @@ Funkcje:
             <cz>[EN] <![CDATA[Annual Tax Rate]]></cz>
             <br>[EN] <![CDATA[Annual Tax Rate]]></br>
             <ru>[EN] <![CDATA[Annual Tax Rate]]></ru>
-            <da><![CDATA[â”œÂ»â”¬â”â”¬Â¢rlig skattesats]]></da>
+            <da><![CDATA[├»┬┐┬¢rlig skattesats]]></da>
         </text>
         <text name="tm_annualrate_long">
             <en><![CDATA[Percentage of accumulated taxes paid each March: Low=2%, Medium=5%, High=10%]]></en>
-            <de><![CDATA[Prozentsatz der angesammelten Steuern, der jeden Mâ”œÂ»â”¬â”â”¬Â¢rz gezahlt wird: Niedrig=2%, Mittel=5%, Hoch=10%]]></de>
-            <fr><![CDATA[Pourcentage des taxes accumulâ”œÂ»â”¬â”â”¬Â¢es payâ”œÂ»â”¬â”â”¬Â¢es chaque mars: Faible=2%, Moyen=5%, â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢=10%]]></fr>
+            <de><![CDATA[Prozentsatz der angesammelten Steuern, der jeden M├»┬┐┬¢rz gezahlt wird: Niedrig=2%, Mittel=5%, Hoch=10%]]></de>
+            <fr><![CDATA[Pourcentage des taxes accumul├»┬┐┬¢es pay├»┬┐┬¢es chaque mars: Faible=2%, Moyen=5%, ├»┬┐┬¢lev├»┬┐┬¢=10%]]></fr>
             <es><![CDATA[Porcentaje de impuestos acumulados pagados cada marzo: Baja=2%, Media=5%, Alta=10%]]></es>
             <it><![CDATA[Percentuale delle tasse accumulate pagate ogni marzo: Bassa=2%, Media=5%, Alta=10%]]></it>
-            <pl><![CDATA[Procent zgromadzonych podatkâ”œÂ»â”¬â”â”¬Â¢w placonych kazdego marca: Niski=2%, Sredni=5%, Wysoki=10%]]></pl>
+            <pl><![CDATA[Procent zgromadzonych podatk├»┬┐┬¢w placonych kazdego marca: Niski=2%, Sredni=5%, Wysoki=10%]]></pl>
             <uk><![CDATA[???????? ??????????? ????????, ?? ??????????? ??????? ???????: ???????=2%, ????????=5%, ???????=10%]]></uk>
         
             <cz>[EN] <![CDATA[Percentage of accumulated taxes paid each March: Low=2%, Medium=5%, High=10%]]></cz>
             <br>[EN] <![CDATA[Percentage of accumulated taxes paid each March: Low=2%, Medium=5%, High=10%]]></br>
             <ru>[EN] <![CDATA[Percentage of accumulated taxes paid each March: Low=2%, Medium=5%, High=10%]]></ru>
-            <da><![CDATA[Procentdel af de akkumulerede skatter, der udbetales hver marts: Lav=2 %, Mellem=5 %, Hâ”œÂ»â”¬â”â”¬Â¢j=10 %]]></da>
+            <da><![CDATA[Procentdel af de akkumulerede skatter, der udbetales hver marts: Lav=2 %, Mellem=5 %, H├»┬┐┬¢j=10 %]]></da>
         </text>
         <text name="tm_annualrate_1"><en><![CDATA[Low (2%)]]></en><de><![CDATA[Niedrig (2%)]]></de><fr><![CDATA[Faible (2%)]]></fr><es><![CDATA[Baja (2%)]]></es><it><![CDATA[Bassa (2%)]]></it><pl><![CDATA[Niski (2%)]]></pl><uk><![CDATA[??????? (2%)]]></uk>
             <cz>[EN] <![CDATA[Low (2%)]]></cz>
@@ -270,19 +270,19 @@ Funkcje:
             <ru>[EN] <![CDATA[Medium (5%)]]></ru>
             <da><![CDATA[Mellem (5 %)]]></da>
         </text>
-        <text name="tm_annualrate_3"><en><![CDATA[High (10%)]]></en><de><![CDATA[Hoch (10%)]]></de><fr><![CDATA[â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢ (10%)]]></fr><es><![CDATA[Alta (10%)]]></es><it><![CDATA[Alta (10%)]]></it><pl><![CDATA[Wysoki (10%)]]></pl><uk><![CDATA[??????? (10%)]]></uk>
+        <text name="tm_annualrate_3"><en><![CDATA[High (10%)]]></en><de><![CDATA[Hoch (10%)]]></de><fr><![CDATA[├»┬┐┬¢lev├»┬┐┬¢ (10%)]]></fr><es><![CDATA[Alta (10%)]]></es><it><![CDATA[Alta (10%)]]></it><pl><![CDATA[Wysoki (10%)]]></pl><uk><![CDATA[??????? (10%)]]></uk>
             <cz>[EN] <![CDATA[High (10%)]]></cz>
             <br>[EN] <![CDATA[High (10%)]]></br>
             <ru>[EN] <![CDATA[High (10%)]]></ru>
-            <da><![CDATA[Hâ”œÂ»â”¬â”â”¬Â¢j (10 %)]]></da>
+            <da><![CDATA[H├»┬┐┬¢j (10 %)]]></da>
         </text>
 
         <!-- Return Percentage (kept for save compatibility) -->
         <text name="tm_return_short">
             <en><![CDATA[Tax Return %]]></en>
-            <de><![CDATA[Steuerrâ”œÂ»â”¬â”â”¬Â¢ckerstattung %]]></de>
+            <de><![CDATA[Steuerr├»┬┐┬¢ckerstattung %]]></de>
             <fr><![CDATA[Remboursement fiscal %]]></fr>
-            <es><![CDATA[% Devoluciâ”œÂ»â”¬â”â”¬Â¢n de impuestos]]></es>
+            <es><![CDATA[% Devoluci├»┬┐┬¢n de impuestos]]></es>
             <it><![CDATA[% Rimborso fiscale]]></it>
             <pl><![CDATA[% Zwrotu podatku]]></pl>
             <uk><![CDATA[% ?????????? ???????]]></uk>
@@ -294,17 +294,17 @@ Funkcje:
         </text>
         <text name="tm_return_long">
             <en><![CDATA[Percentage of monthly taxes returned at the start of each new month: Low=10%, Medium=20%, High=30%]]></en>
-            <de><![CDATA[Prozentsatz der monatlichen Steuern, der zurâ”œÂ»â”¬â”â”¬Â¢ckerstattet wird: Niedrig=10%, Mittel=20%, Hoch=30%]]></de>
-            <fr><![CDATA[Pourcentage des taxes mensuelles remboursâ”œÂ»â”¬â”â”¬Â¢es: Faible=10%, Moyen=20%, â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢=30%]]></fr>
+            <de><![CDATA[Prozentsatz der monatlichen Steuern, der zur├»┬┐┬¢ckerstattet wird: Niedrig=10%, Mittel=20%, Hoch=30%]]></de>
+            <fr><![CDATA[Pourcentage des taxes mensuelles rembours├»┬┐┬¢es: Faible=10%, Moyen=20%, ├»┬┐┬¢lev├»┬┐┬¢=30%]]></fr>
             <es><![CDATA[Porcentaje de impuestos mensuales devueltos: Baja=10%, Media=20%, Alta=30%]]></es>
             <it><![CDATA[Percentuale delle tasse mensili rimborsate: Bassa=10%, Media=20%, Alta=30%]]></it>
-            <pl><![CDATA[Procent miesiecznych podatkâ”œÂ»â”¬â”â”¬Â¢w zwracanych: Niski=10%, Sredni=20%, Wysoki=30%]]></pl>
+            <pl><![CDATA[Procent miesiecznych podatk├»┬┐┬¢w zwracanych: Niski=10%, Sredni=20%, Wysoki=30%]]></pl>
             <uk><![CDATA[???????? ???????? ????????, ?? ???????????? ?? ??????? ??????: ???????=10%, ????????=20%, ???????=30%]]></uk>
         
             <cz>[EN] <![CDATA[Percentage of monthly taxes returned at the start of each new month: Low=10%, Medium=20%, High=30%]]></cz>
             <br>[EN] <![CDATA[Percentage of monthly taxes returned at the start of each new month: Low=10%, Medium=20%, High=30%]]></br>
             <ru>[EN] <![CDATA[Percentage of monthly taxes returned at the start of each new month: Low=10%, Medium=20%, High=30%]]></ru>
-            <da><![CDATA[Procentdel af de mâ”œÂ»â”¬â”â”¬Â¢nedlige skatter, der tilbagebetales ved starten af hver ny mâ”œÂ»â”¬â”â”¬Â¢ned: Lav=10 %, Mellem=20 %, Hâ”œÂ»â”¬â”â”¬Â¢j=30 %]]></da>
+            <da><![CDATA[Procentdel af de m├»┬┐┬¢nedlige skatter, der tilbagebetales ved starten af hver ny m├»┬┐┬¢ned: Lav=10 %, Mellem=20 %, H├»┬┐┬¢j=30 %]]></da>
         </text>
         <text name="tm_return_1"><en><![CDATA[Low (10%)]]></en><de><![CDATA[Niedrig (10%)]]></de><fr><![CDATA[Faible (10%)]]></fr><es><![CDATA[Baja (10%)]]></es><it><![CDATA[Bassa (10%)]]></it><pl><![CDATA[Niski (10%)]]></pl><uk><![CDATA[??????? (10%)]]></uk>
             <cz>[EN] <![CDATA[Low (10%)]]></cz>
@@ -318,11 +318,11 @@ Funkcje:
             <ru>[EN] <![CDATA[Medium (20%)]]></ru>
             <da><![CDATA[Mellem (20 %)]]></da>
         </text>
-        <text name="tm_return_3"><en><![CDATA[High (30%)]]></en><de><![CDATA[Hoch (30%)]]></de><fr><![CDATA[â”œÂ»â”¬â”â”¬Â¢levâ”œÂ»â”¬â”â”¬Â¢ (30%)]]></fr><es><![CDATA[Alta (30%)]]></es><it><![CDATA[Alta (30%)]]></it><pl><![CDATA[Wysoki (30%)]]></pl><uk><![CDATA[??????? (30%)]]></uk>
+        <text name="tm_return_3"><en><![CDATA[High (30%)]]></en><de><![CDATA[Hoch (30%)]]></de><fr><![CDATA[├»┬┐┬¢lev├»┬┐┬¢ (30%)]]></fr><es><![CDATA[Alta (30%)]]></es><it><![CDATA[Alta (30%)]]></it><pl><![CDATA[Wysoki (30%)]]></pl><uk><![CDATA[??????? (30%)]]></uk>
             <cz>[EN] <![CDATA[High (30%)]]></cz>
             <br>[EN] <![CDATA[High (30%)]]></br>
             <ru>[EN] <![CDATA[High (30%)]]></ru>
-            <da><![CDATA[Hâ”œÂ»â”¬â”â”¬Â¢j (30 %)]]></da>
+            <da><![CDATA[H├»┬┐┬¢j (30 %)]]></da>
         </text>
 
         <!-- Notifications -->
@@ -342,8 +342,8 @@ Funkcje:
         </text>
         <text name="tm_notifications_long">
             <en><![CDATA[Show in-game notifications when taxes are deducted or returns are paid]]></en>
-            <de><![CDATA[In-Game-Benachrichtigungen anzeigen, wenn Steuern abgezogen oder Râ”œÂ»â”¬â”â”¬Â¢ckerstattungen gezahlt werden]]></de>
-            <fr><![CDATA[Afficher les notifications en jeu lors des dâ”œÂ»â”¬â”â”¬Â¢ductions fiscales ou des remboursements]]></fr>
+            <de><![CDATA[In-Game-Benachrichtigungen anzeigen, wenn Steuern abgezogen oder R├»┬┐┬¢ckerstattungen gezahlt werden]]></de>
+            <fr><![CDATA[Afficher les notifications en jeu lors des d├»┬┐┬¢ductions fiscales ou des remboursements]]></fr>
             <es><![CDATA[Mostrar notificaciones en el juego cuando se deducen impuestos o se pagan devoluciones]]></es>
             <it><![CDATA[Mostra notifiche in gioco quando vengono detratte le tasse o pagati i rimborsi]]></it>
             <pl><![CDATA[Pokazuj powiadomienia w grze gdy podatki sa odliczane lub zwracane]]></pl>
@@ -352,7 +352,7 @@ Funkcje:
             <cz>[EN] <![CDATA[Show in-game notifications when taxes are deducted or returns are paid]]></cz>
             <br>[EN] <![CDATA[Show in-game notifications when taxes are deducted or returns are paid]]></br>
             <ru>[EN] <![CDATA[Show in-game notifications when taxes are deducted or returns are paid]]></ru>
-            <da><![CDATA[Vis notifikationer i spillet, nâ”œÂ»â”¬â”â”¬Â¢r skatter fratrâ”œÂ»â”¬â”â”¬Â¢kkes eller refusioner udbetales]]></da>
+            <da><![CDATA[Vis notifikationer i spillet, n├»┬┐┬¢r skatter fratr├»┬┐┬¢kkes eller refusioner udbetales]]></da>
         </text>
 
         <!-- Show HUD -->
@@ -372,17 +372,17 @@ Funkcje:
         </text>
         <text name="tm_show_hud_long">
             <en><![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with T key)]]></en>
-            <de><![CDATA[Tax-HUD mit aktuellem Steuersatz, Statistiken und letzten Aktivitâ”œÂ»â”¬â”â”¬Â¢ten anzeigen (mit T umschalten)]]></de>
-            <fr><![CDATA[Afficher l'HUD fiscal avec le taux actuel, les statistiques et l'activitâ”œÂ»â”¬â”â”¬Â¢ râ”œÂ»â”¬â”â”¬Â¢cente (basculer avec T)]]></fr>
-            <es><![CDATA[Mostrar el HUD fiscal con la tasa actual, estadâ”œÂ»â”¬â”â”¬Â¢sticas y actividad reciente (alternar con T)]]></es>
-            <it><![CDATA[Mostra l'HUD fiscale con aliquota corrente, statistiche e attivitâ”œÂ»â”¬â”â”¬Â¢ recente (attiva/disattiva con T)]]></it>
+            <de><![CDATA[Tax-HUD mit aktuellem Steuersatz, Statistiken und letzten Aktivit├»┬┐┬¢ten anzeigen (mit T umschalten)]]></de>
+            <fr><![CDATA[Afficher l'HUD fiscal avec le taux actuel, les statistiques et l'activit├»┬┐┬¢ r├»┬┐┬¢cente (basculer avec T)]]></fr>
+            <es><![CDATA[Mostrar el HUD fiscal con la tasa actual, estad├»┬┐┬¢sticas y actividad reciente (alternar con T)]]></es>
+            <it><![CDATA[Mostra l'HUD fiscale con aliquota corrente, statistiche e attivit├»┬┐┬¢ recente (attiva/disattiva con T)]]></it>
             <pl><![CDATA[Pokaz HUD podatkowy z biezaca stawka, statystykami i ostatnia aktywnoscia (przelacz klawiszem T)]]></pl>
             <uk><![CDATA[???????? HUD ???????? ? ???????? ???????, ??????????? ?? ??????????? ?????????? (?????????? ???????? T)]]></uk>
         
             <cz>[EN] <![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with T key)]]></cz>
             <br>[EN] <![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with T key)]]></br>
             <ru>[EN] <![CDATA[Show the Tax HUD overlay with current rate, statistics and recent activity (toggle with T key)]]></ru>
-            <da><![CDATA[Vis skatte-HUD-overlayet med aktuel sats, statistik og seneste aktivitet (slâ”œÂ»â”¬â”â”¬Â¢ til/fra med T-tasten)]]></da>
+            <da><![CDATA[Vis skatte-HUD-overlayet med aktuel sats, statistik og seneste aktivitet (sl├»┬┐┬¢ til/fra med T-tasten)]]></da>
         </text>
 
         <!-- HUD toggle key binding display name -->
@@ -397,7 +397,7 @@ Funkcje:
             <cz>[EN] <![CDATA[Toggle Tax HUD]]></cz>
             <br>[EN] <![CDATA[Toggle Tax HUD]]></br>
             <ru>[EN] <![CDATA[Toggle Tax HUD]]></ru>
-            <da><![CDATA[Slâ”œÂ»â”¬â”â”¬Â¢ skatte-HUD til/fra]]></da>
+            <da><![CDATA[Sl├»┬┐┬¢ skatte-HUD til/fra]]></da>
         </text>
         <text name="input_TM_HUD_DRAG">
             <en>Tax HUD Edit Mode</en>
@@ -821,32 +821,32 @@ Funkcje:
             <vi><![CDATA[[EN] Tax posture glance: on/off, bill, March, balance share, countdown, lifetime paid, ledger summary.]]></vi>
         </text>
         <text name="tax_rf_pda_hint_rates">
-            <en><![CDATA[Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></en>
-            <de><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></de>
-            <fr><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></fr>
-            <pl><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></pl>
-            <es><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></es>
-            <it><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></it>
-            <cz><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></cz>
-            <br><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></br>
-            <uk><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></uk>
-            <ru><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></ru>
-            <da><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></da>
-            <ct><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></ct>
-            <ea><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></ea>
-            <fc><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></fc>
-            <fi><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></fi>
-            <hu><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></hu>
-            <id><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></id>
-            <jp><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></jp>
-            <kr><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></kr>
-            <nl><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></nl>
-            <no><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></no>
-            <pt><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></pt>
-            <ro><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></ro>
-            <sv><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></sv>
-            <tr><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></tr>
-            <vi><![CDATA[[EN] Daily rate: %s (%.0f%%) â”œÃ©â”¬Ã€ March rate: %.0f%% â”œÃ©â”¬Ã€ Min balance: %s]]></vi>
+            <en><![CDATA[Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></en>
+            <de><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></de>
+            <fr><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></fr>
+            <pl><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></pl>
+            <es><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></es>
+            <it><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></it>
+            <cz><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></cz>
+            <br><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></br>
+            <uk><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></uk>
+            <ru><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></ru>
+            <da><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></da>
+            <ct><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></ct>
+            <ea><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></ea>
+            <fc><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></fc>
+            <fi><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></fi>
+            <hu><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></hu>
+            <id><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></id>
+            <jp><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></jp>
+            <kr><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></kr>
+            <nl><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></nl>
+            <no><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></no>
+            <pt><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></pt>
+            <ro><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></ro>
+            <sv><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></sv>
+            <tr><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></tr>
+            <vi><![CDATA[[EN] Daily rate: %s (%.0f%%) ├é┬À March rate: %.0f%% ├é┬À Min balance: %s]]></vi>
         </text>
         <text name="tax_rf_pda_lbl_min_balance">
             <en><![CDATA[Min balance]]></en>

--- a/src/gui/TaxRfPdaGuest.lua
+++ b/src/gui/TaxRfPdaGuest.lua
@@ -154,77 +154,98 @@ local function monthsUntil(target, current)
     return d
 end
 
-local _guiWarned = false
-local _baseline = nil   -- captured once, before the first move, for onHide restore
+local _statusWarned = false
 
--- Wizard eyes-on: Status posture moves out of the top band into the lower empty band,
--- with bigger type. Left column = lines 1-4 at x=0, right column = lines 5-8 at x=580.
-local TAX_LINE_POS = {
-    [1] = { "0px",   "-280px" }, [5] = { "580px", "-280px" },
-    [2] = { "0px",   "-328px" }, [6] = { "580px", "-328px" },
-    [3] = { "0px",   "-376px" }, [7] = { "580px", "-376px" },
-    [4] = { "0px",   "-424px" }, [8] = { "580px", "-424px" },
+-- BUILD 16:32. The densify that used to live here moved rfFwLine1..8 to -280..-480 with
+-- 26px type and X reset to 0. That was written for an unframed 580-tall status block,
+-- where the lower band really was empty space. BUILD 15:35 put a 340-tall white stroke
+-- round that block, so the same move now drops the whole status band under the bottom
+-- rule and leaves an empty white box above it: the FAIL Wizard saw.
+--
+-- BUILD 20:37. Deleting the densify was only half of it. What replaced it captured the
+-- element positions on the FIRST show and re-asserted those, which is only the XML baseline
+-- if nothing had moved the shell before that first show. If anything had, the capture froze
+-- the bad layout and every later show put it back faithfully. A one-shot capture cannot tell
+-- a baseline from a mistake, so the locks are written out instead.
+--
+-- These px are read from this mod's own xml/gui/RfPdaMenuPage.xml and must stay equal to it.
+-- The XML remains the one place that says where status text lives; this file's job is only
+-- to put it back there if anything moved it.
+local FW_STATUS_BLOCK = { "rfFwStatusBlock", "0px", "0px", "1140px", "340px" }
+-- Two columns of four. Left at 10, right at 580, sharing the four Y axes.
+local FW_STATUS_LINES = {
+    { "rfFwLine1", "10px", "-8px" },
+    { "rfFwLine2", "10px", "-56px" },
+    { "rfFwLine3", "10px", "-104px" },
+    { "rfFwLine4", "10px", "-152px" },
+    { "rfFwLine5", "580px", "-8px" },
+    { "rfFwLine6", "580px", "-56px" },
+    { "rfFwLine7", "580px", "-104px" },
+    { "rfFwLine8", "580px", "-152px" }
 }
-local TAX_HINT_POS  = { "0px", "-480px" }
-local TAX_TEXT_SIZE = "26px"
+-- 550 wide, not 580: a line grown to 580 would run into the right column's own left edge.
+local FW_LINE_W, FW_LINE_H = "550px", "22px"
+local FW_STATUS_HINT = { "rfFwHint", "10px", "-208px", "1120px", "120px" }
 
---- position and textSize are NORMALISED in FS25 (TextElement default textSize is 0.03),
---- so raw pixel numbers would throw the layout off-screen. Always go through GuiUtils.
---- Nil-safe: if the normalizer is missing we leave the XML baseline rather than guess.
-local function guiOk()
+--- Put the Status shell back on the XML locks. Runs every show, so a move from any earlier
+--- session, or from a stale artifact still sitting in My Games, cannot survive into this one.
+---
+--- textSize is never written. The profile owns the type, and since there is no way to unset a
+--- text size once it has been set, the only way to leave type alone is to never touch it.
+local function restoreStatusBand(container)
+    if container == nil then
+        return
+    end
     if GuiUtils == nil or type(GuiUtils.getNormalizedXValue) ~= "function"
-        or type(GuiUtils.getNormalizedYValue) ~= "function" then
-        if not _guiWarned then
-            _guiWarned = true
-            print("[TaxMod] TaxRfPdaGuest: GuiUtils normalizer absent - leaving Status lines at XML baseline")
+        or type(GuiUtils.getNormalizedYValue) ~= "function"
+        or type(GuiUtils.getNormalizedScreenValues) ~= "function" then
+        if not _statusWarned then
+            _statusWarned = true
+            print("[RF] Tax status band: GuiUtils normalizer absent - leaving the XML geometry")
         end
-        return false
+        return
     end
-    return true
-end
 
---- Remember where the shared Status shell started, once, so onHide can put it back.
-local function captureBaseline(container)
-    if _baseline ~= nil then return end
-    _baseline = {}
-    for i = 1, 8 do
-        local el = findDescendant(container, "rfFwLine" .. i)
-        if el ~= nil then
-            _baseline["rfFwLine" .. i] = { x = el.position and el.position[1], y = el.position and el.position[2],
-                                           textSize = el.textSize }
+    local function place(id, xPx, yPx, wPx, hPx)
+        local el = findDescendant(container, id)
+        if el == nil then
+            return
         end
+        if type(el.setPosition) == "function" then
+            el:setPosition(GuiUtils.getNormalizedXValue(xPx, 0),
+                           GuiUtils.getNormalizedYValue(yPx, 0))
+        end
+        if wPx ~= nil and hPx ~= nil and type(el.setSize) == "function" then
+            local norms = GuiUtils.getNormalizedScreenValues(wPx .. " " .. hPx)
+            if type(norms) == "table" and norms[1] ~= nil and norms[2] ~= nil then
+                el:setSize(norms[1], norms[2])
+            end
+        end
+        if type(el.updateAbsolutePosition) == "function" then el:updateAbsolutePosition() end
     end
-    local h = findDescendant(container, "rfFwHint")
-    if h ~= nil then
-        _baseline.rfFwHint = { x = h.position and h.position[1], y = h.position and h.position[2], textSize = h.textSize }
-    end
-end
 
-local function applyStatusBand(container)
-    if not guiOk() then return end
-    captureBaseline(container)
-    local size = GuiUtils.getNormalizedYValue(TAX_TEXT_SIZE, nil)
+    -- The card first, so the lines are placed inside a block that is already the right size.
+    place(FW_STATUS_BLOCK[1], FW_STATUS_BLOCK[2], FW_STATUS_BLOCK[3],
+          FW_STATUS_BLOCK[4], FW_STATUS_BLOCK[5])
+    -- A literal 1..8 walk. An ipairs over this table would stop at the first nil if an edit
+    -- ever left a hole in it, and silently place only the left column, which is the exact
+    -- shape of the bug this suite paid for at 21:54.
     for i = 1, 8 do
-        local el = findDescendant(container, "rfFwLine" .. i)
-        local pos = TAX_LINE_POS[i]
-        if el ~= nil and pos ~= nil and type(el.setPosition) == "function" then
-            el:setPosition(GuiUtils.getNormalizedXValue(pos[1], 0), GuiUtils.getNormalizedYValue(pos[2], 0))
-            if size ~= nil and type(el.setTextSize) == "function" then el:setTextSize(size) end
-            if type(el.updateAbsolutePosition) == "function" then el:updateAbsolutePosition() end
+        local row = FW_STATUS_LINES[i]
+        if row ~= nil then
+            place(row[1], row[2], row[3], FW_LINE_W, FW_LINE_H)
         end
     end
-    local h = findDescendant(container, "rfFwHint")
-    if h ~= nil and type(h.setPosition) == "function" then
-        h:setPosition(GuiUtils.getNormalizedXValue(TAX_HINT_POS[1], 0), GuiUtils.getNormalizedYValue(TAX_HINT_POS[2], 0))
-        if size ~= nil and type(h.setTextSize) == "function" then h:setTextSize(size) end
-        if type(h.updateAbsolutePosition) == "function" then h:updateAbsolutePosition() end
-    end
+    place(FW_STATUS_HINT[1], FW_STATUS_HINT[2], FW_STATUS_HINT[3],
+          FW_STATUS_HINT[4], FW_STATUS_HINT[5])
 end
 
 function TaxRfPdaGuest.onShow(container, lightOnly)
     clearHostDupes(container)
     showStatusMode(container)
-    applyStatusBand(container)
+    -- Every show, straight from the XML locks. Nothing is captured, so nothing can be
+    -- frozen wrong on a first show that happened to land after something moved the shell.
+    restoreStatusBand(container)
     paintSide(container, "rf_pda_side_info_tax",
         "Tax posture: on/off, year bill, March estimate, balance share, countdown.\n"
         .. "Daily rate and March rate differ. Esc never pays tax - use Tax HUD / Settings.")
@@ -315,22 +336,12 @@ function TaxRfPdaGuest.onShow(container, lightOnly)
     setText(findDescendant(container, "rfFwHint"), hint)
 end
 
---- Restore the Status shell to the baseline captured before the first move.
---- Status is currently tax-only (host maps isFwStatus = "tax"), so nothing else can be
---- stranded by these moves - but no host calls onHide today (verified across the suite),
---- so this is correct-when-wired rather than live. onShow re-applies the band every time.
+--- Hand the Status shell back on the XML locks. Status is tax-only today (host maps
+--- isFwStatus = "tax") and no host calls onHide, so this is correct-when-wired rather than
+--- live; it stays because the day status is shared is the day it matters, and onShow now
+--- re-asserts the same locks anyway.
 function TaxRfPdaGuest.onHide(container)
-    if container == nil or _baseline == nil then return end
-    local function restore(id)
-        local b = _baseline[id]
-        local el = findDescendant(container, id)
-        if b == nil or el == nil then return end
-        if b.x ~= nil and b.y ~= nil and type(el.setPosition) == "function" then el:setPosition(b.x, b.y) end
-        if b.textSize ~= nil and type(el.setTextSize) == "function" then el:setTextSize(b.textSize) end
-        if type(el.updateAbsolutePosition) == "function" then el:updateAbsolutePosition() end
-    end
-    for i = 1, 8 do restore("rfFwLine" .. i) end
-    restore("rfFwHint")
+    restoreStatusBand(container)
 end
 
 function TaxRfPdaGuest.tryRegister()

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -209,18 +209,30 @@
 
                         <!-- Card 2 of 3 (BUILD 12:59): Selected + Next now live INSIDE the
                              PRODUCTS card, so the card owns the whole middle column. -->
-                        <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px">
-                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="540px 20px"
+                        <!-- GO 21:06 (BUILD 21:01): PRODUCTS was inheriting 560 from
+                             RF_EscCardFrame, so its right edge sat at 220 + 560 = 780 against
+                             ROTATION at 850: a dark 70px canyon down the middle of a three-card
+                             family. The inline 620 lands the right edge on 840, leaving 10px of
+                             air, and TREATMENT already ends at 210 against PRODUCTS at 220, so
+                             both gutters read as the same gap. Family rhythm, not a kiss.
+                             Bodies follow 540 -> 600 in step so the 10px left inset is kept and
+                             nothing is re-centred; RATE and TOTAL keep their left-anchored
+                             recipe and simply gain trailing air.
+                             This edit is in ALL NINE door copies on purpose. The Esc page is
+                             built by whichever mod loads first, from its own copy, so a change
+                             in Soil alone would be overwritten by whoever won the race. -->
+                        <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px" size="620px 248px">
+                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="600px 20px"
                                   textAlignment="left"/>
-                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="540px 36px"
+                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="600px 36px"
                                   textAlignment="left" textMaxNumLines="2" textVerticalAlignment="top"/>
                             <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then ~16px of
                                  air with one 1px hairline centred in it, then the PRODUCTS table.
                                  One outer outline only; the rule is a Bitmap, not a second frame.
                                  Bodies inset X 0 -> 10 and widths 560 -> 540 so nothing kisses the
                                  white stroke on either side. -->
-                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="540px 1px"/>
-                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="540px 18px"
+                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="600px 1px"/>
+                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="600px 18px"
                                   text="$l10n_rf_pda_treat_products"/>
                             <Text profile="RF_ProductColHeaderDense" position="10px -100px" size="40px 16px" text="NUT"/>
                             <Text profile="RF_ProductColHeaderDense" position="54px -100px" size="270px 16px" text="PRODUCT"/>
@@ -228,54 +240,54 @@
                                   textAlignment="right" text="RATE"/>
                             <Text profile="RF_ProductColHeaderDense" position="440px -100px" size="110px 16px"
                                   textAlignment="right" text="TOTAL"/>
-                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="540px 22px"
+                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="600px 22px"
                                   visible="false"/>
                             <!-- Clip sized to exactly the eight densified rows (8 x 15 = 120), so the
                                  card bottom keeps 8px of air instead of cutting row 8 mid-glyph. -->
-                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="540px 120px">
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="540px 15px" visible="false">
+                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="600px 120px">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd1Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd1Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd1Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd1Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow2" position="0px -15px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow2" position="0px -15px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd2Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd2Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd2Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd2Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow3" position="0px -30px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow3" position="0px -30px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd3Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd3Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd3Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd3Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow4" position="0px -45px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow4" position="0px -45px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd4Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd4Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd4Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd4Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow5" position="0px -60px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow5" position="0px -60px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd5Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd5Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd5Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd5Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow6" position="0px -75px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow6" position="0px -75px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd6Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd6Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd6Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd6Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow7" position="0px -90px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow7" position="0px -90px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd7Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd7Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd7Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd7Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow8" position="0px -105px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow8" position="0px -105px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd8Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd8Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd8Rate" position="320px 0px" size="100px 15px"/>
@@ -341,58 +353,80 @@
                     <!-- Worker Costs page bodies only (page chrome = left sibling band). -->
                     <GuiElement profile="RF_WcPageShell" id="wcPageShell" visible="false">
                         <!-- Dashboard -->
-                        <GuiElement profile="RF_WcPage" id="wcPageDashboard" visible="true">
-                            <Text profile="RF_TreatTargetLine" id="wcDashStatus" position="0px 0px" size="1140px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashMode" position="0px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashWage" position="580px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashRate" position="0px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashWorkers" position="580px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashEstimate" position="0px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashCountdown" position="580px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcDashWorkerNames" position="0px -200px" size="1140px 280px"
+                        <!-- Dashboard is the only WC page that gets the white card (Ash 15:35 #2):
+                             Wages/Workers/About carry MTOs and their own chrome. Framed on
+                             wcPageDashboard itself, not a new inner shell, so nothing double-frames.
+                             Body cells inset 10px L/R and 8px down; worker names still 280 tall and
+                             end at -488 of 500, so 12px of bottom air and no clip. -->
+                        <GuiElement profile="RF_EscCardFrameWide" id="wcPageDashboard" visible="true">
+                            <Text profile="RF_TreatTargetLine" id="wcDashStatus" position="10px -8px" size="1120px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashMode" position="10px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashWage" position="580px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashRate" position="10px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashWorkers" position="580px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashEstimate" position="10px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashCountdown" position="580px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_HintText" id="wcDashWorkerNames" position="10px -208px" size="1120px 280px"
                                   textMaxNumLines="12" textVerticalAlignment="top" text=""/>
                         </GuiElement>
 
                         <!-- Wages: tight label+option rows; summary/help/Reset UNDER stack (no 760 side column). -->
+                        <!-- Two cards, not one: settings stack up, summary/help/Reset below, 16px of
+                             clear air between the strokes. The page itself stays unframed - a frame on
+                             RF_WcPage would be the mega-shell over the MTOs George vetoed. Wrappers carry
+                             handleFocus=false so nothing between the player and an option can take a click,
+                             and the MTOs are still found by getDescendantById, which does not care how deep
+                             they sit. Card B trims one internal gap by 8px, which is exactly what the two
+                             strokes plus their air cost, so wcBtnWageReset lands back on -536 and the page
+                             stays 580 tall. Nothing grew to make room. -->
                         <GuiElement profile="RF_WcPage" id="wcPageWages" size="1140px 580px" visible="false">
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblEnabled" position="0px 8px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptEnabled" position="220px 0px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblMode" position="0px -44px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptCostMode" position="220px -52px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblLevel" position="0px -96px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptWageLevel" position="220px -104px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblNotify" position="0px -148px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptNotifications" position="220px -156px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblDebug" position="0px -200px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptDebugMode" position="220px -208px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblSalary" position="0px -252px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptMonthlySalary" position="220px -260px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <!-- Summary band under last option (~-260); full width; not overlapping options. -->
-                            <Text profile="RF_SectionTitle" id="wcWageBigRate" position="0px -340px" size="1140px 36px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageRateLabel" position="0px -384px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcWagePayInterval" position="580px -384px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcWageHelpBody" position="0px -420px" size="1140px 100px"
-                                  textMaxNumLines="4" textVerticalAlignment="top" text=""/>
-                            <Button profile="buttonActivate" id="wcBtnWageReset" position="0px -536px" size="200px 36px"
-                                    text="Reset" onClick="onClickWcWageReset"/>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWagesCardA" position="0px 0px" size="1140px 326px" handleFocus="false">
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblEnabled" position="10px -10px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptEnabled" position="230px -18px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblMode" position="10px -62px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptCostMode" position="230px -70px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblLevel" position="10px -114px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptWageLevel" position="230px -122px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblNotify" position="10px -166px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptNotifications" position="230px -174px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblDebug" position="10px -218px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptDebugMode" position="230px -226px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblSalary" position="10px -270px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptMonthlySalary" position="230px -278px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                            </GuiElement>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWagesCardB" position="0px -342px" size="1140px 238px" handleFocus="false">
+                                <Text profile="RF_SectionTitle" id="wcWageBigRate" position="10px -6px" size="1120px 36px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageRateLabel" position="10px -50px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcWagePayInterval" position="580px -50px" size="550px 22px" text=""/>
+                                <Text profile="RF_HintText" id="wcWageHelpBody" position="10px -86px" size="1120px 100px"
+                                      textMaxNumLines="4" textVerticalAlignment="top" text=""/>
+                                <Button profile="buttonActivate" id="wcBtnWageReset" position="10px -194px" size="200px 36px"
+                                        text="Reset" onClick="onClickWcWageReset"/>
+                            </GuiElement>
                         </GuiElement>
 
                         <!-- Workers -->
+                        <!-- Same family as Wages: stats card, 16px of air, then the worker list card.
+                             wcStatsWorkerList stays fixed Text rows, no SmoothList. -->
                         <GuiElement profile="RF_WcPage" id="wcPageWorkers" visible="false">
-                            <Text profile="RF_TreatTargetLine" id="wcStatsMode" position="0px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsWage" position="580px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsInterval" position="0px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsCount" position="580px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsCostPer" position="0px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsTotal" position="580px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcStatsWorkerList" position="0px -160px" size="1140px 320px"
-                                  textMaxNumLines="14" textVerticalAlignment="top" text=""/>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWorkersCardA" position="0px 0px" size="1140px 136px" handleFocus="false">
+                                <Text profile="RF_TreatTargetLine" id="wcStatsMode" position="10px -10px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsWage" position="580px -10px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsInterval" position="10px -58px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsCount" position="580px -58px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsCostPer" position="10px -106px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsTotal" position="580px -106px" size="550px 22px" text=""/>
+                            </GuiElement>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWorkersCardB" position="0px -152px" size="1140px 338px" handleFocus="false">
+                                <Text profile="RF_HintText" id="wcStatsWorkerList" position="10px -10px" size="1120px 320px"
+                                      textMaxNumLines="14" textVerticalAlignment="top" text=""/>
+                            </GuiElement>
                         </GuiElement>
 
                         <!-- About page retired 2026-08-02: copy lives in wcSideInfoShell. Keep shell for nil-safe ids. -->
@@ -417,61 +451,84 @@
                          Text-only; no onClick. Visible only for framework module ids.
                          George 2026-08-05: shell 0/-20 (X flush + B1 blurb-48 clearance); titles hidden; rows +36. -->
                     <GuiElement profile="RF_WcPageShell" id="rfFrameworkGlanceShell" visible="false" position="0px 0px">
-                        <GuiElement id="rfFwStatusBlock" visible="true" position="0px 0px" size="1140px 580px">
-                            <Text profile="RF_SectionTitle" id="rfFwStatusTitle" position="0px 0px" size="1140px 24px" text="" visible="false"/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine1" position="0px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine2" position="0px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine3" position="0px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine4" position="0px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine5" position="580px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine6" position="580px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine7" position="580px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine8" position="580px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="rfFwHint" position="0px -200px" size="1140px 120px"
+                        <!-- Income / Tax / Depot status glance. 580 was taller than the shell (520);
+                             the card is sized to its content instead: hint ends at -328, so 340
+                             leaves 12px of bottom air inside the stroke. -->
+                        <GuiElement profile="RF_EscCardFrameWide" id="rfFwStatusBlock" visible="true" position="0px 0px" size="1140px 340px">
+                            <Text profile="RF_SectionTitle" id="rfFwStatusTitle" position="10px -8px" size="1120px 24px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine1" position="10px -8px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine2" position="10px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine3" position="10px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine4" position="10px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine5" position="580px -8px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine6" position="580px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine7" position="580px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine8" position="580px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_HintText" id="rfFwHint" position="10px -208px" size="1120px 120px"
                                   textMaxNumLines="4" textVerticalAlignment="top" text=""/>
                         </GuiElement>
-                        <GuiElement id="rfFwTableBlock" visible="false" position="0px 0px" size="1140px 580px">
-                            <Text profile="RF_SectionTitle" id="rfFwTableTitle" position="0px 0px" size="1140px 24px" text="" visible="false"/>
-                            <Text profile="RF_ColHeader" id="rfFwColA" position="0px -32px" size="280px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="rfFwColB" position="300px -32px" size="280px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="rfFwColC" position="600px -32px" size="220px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="rfFwColD" position="840px -32px" size="280px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="0px -60px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="300px -60px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="600px -60px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="840px -60px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="0px -88px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="300px -88px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="600px -88px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="840px -88px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="0px -116px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="300px -116px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="600px -116px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="840px -116px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="0px -144px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="300px -144px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="600px -144px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="840px -144px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="0px -172px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="300px -172px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="600px -172px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="840px -172px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="0px -200px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="300px -200px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="600px -200px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="840px -200px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="0px -228px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="300px -228px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="600px -228px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="840px -228px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="0px -256px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="300px -256px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="600px -256px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="840px -256px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="0px -292px" size="1140px 20px" text=""/>
-                            <Text profile="RF_HintText" id="rfFwEmptyHint" position="0px -60px" size="1140px 44px"
+                        <!-- Dairy / NPC Favor table glance. Content runs to -416 (hint under the rows),
+                             so 428 gives the same 12px of bottom air. Only one of the two blocks is
+                             ever visible (setVis is an either/or), so no card is ever naked beside
+                             another - Ash 15:35 #1 sibling framing has nothing to bite on here. -->
+                        <GuiElement profile="RF_EscCardFrameWide" id="rfFwTableBlock" visible="false" position="0px 0px" size="1140px 428px">
+                            <Text profile="RF_SectionTitle" id="rfFwTableTitle" position="10px -8px" size="1120px 24px" text="" visible="false"/>
+                            <!-- Excel sheet: the outer border is rfFwTableBlock's own hasFrame; these 11 hairlines
+                                 are the inner grid. RF_EscCardRule is already blank.png + soft grey 0.55, so they
+                                 take it with an inline size rather than one profile per orientation. Declared
+                                 before the cells so text paints over them. Per-cell hasFrame would have been 144
+                                 frame rects for the same picture. -->
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleHead" position="10px -64px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow1" position="10px -92px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow2" position="10px -120px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow3" position="10px -148px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow4" position="10px -176px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow5" position="10px -204px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow6" position="10px -232px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow7" position="10px -260px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol1" position="300px -36px" size="1px 250px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol2" position="600px -36px" size="1px 250px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol3" position="840px -36px" size="1px 250px"/>
+                            <Text profile="RF_FwColHeader" id="rfFwColA" position="10px -40px" size="280px 22px" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwColB" position="310px -40px" size="280px 22px" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwColC" position="610px -40px" size="220px 22px" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwColD" position="850px -40px" size="280px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="10px -68px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="310px -68px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="610px -68px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="850px -68px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="10px -96px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="310px -96px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="610px -96px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="850px -96px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="10px -124px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="310px -124px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="610px -124px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="850px -124px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="10px -152px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="310px -152px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="610px -152px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="850px -152px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="10px -180px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="310px -180px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="610px -180px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="850px -180px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="10px -208px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="310px -208px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="610px -208px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="850px -208px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="10px -236px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="310px -236px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="610px -236px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="850px -236px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="10px -264px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="310px -264px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -300px" size="1120px 20px" text=""/>
+                            <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-                            <Text profile="RF_HintText" id="rfFwHintTable" position="0px -328px" size="1140px 80px"
+                            <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"
                                   textMaxNumLines="3" textVerticalAlignment="top" text=""/>
                         </GuiElement>
                     </GuiElement>
@@ -710,23 +767,23 @@
                         <Bitmap profile="RF_TreatmentBoxBg"/>
 
                         <!-- Page A — Prices -->
-                        <GuiElement id="mdPricesBand" visible="true" position="0px 0px" size="100% 100%">
+                        <GuiElement profile="RF_EscCardFrameWide" id="mdPricesBand" visible="true" position="10px -10px" size="1130px 344px">
                             <Text profile="RF_SectionTitle" id="mdGraphTitle" position="10px -6px" size="700px 22px" text=""/>
-                            <GuiElement profile="RF_MdGraphArea" id="mdGraphArea"/>
-            <Text profile="RF_EmptyHint" id="mdGraphEmptyHint" position="40px -96px" size="720px 40px"
+                            <GuiElement profile="RF_MdGraphArea" id="mdGraphArea" position="30px -28px"/>
+            <Text profile="RF_EmptyHint" id="mdGraphEmptyHint" position="30px -86px" size="720px 40px"
                   visible="false" text=""/>
-            <Text profile="RF_TreatSelected" id="mdDetailCommodity" position="770px -32px" size="380px 22px"
+            <Text profile="RF_TreatSelected" id="mdDetailCommodity" position="770px -32px" size="350px 22px"
                   textAlignment="left" text=""/>
-            <Text profile="RF_TreatTargetLine" id="mdDetailPrice" position="770px -64px" size="380px 20px" text=""/>
-            <Text profile="RF_TreatTargetLine" id="mdDetailPressure" position="770px -92px" size="380px 20px" text=""/>
-            <Text profile="RF_HintText" id="mdDetailEmpty" position="770px -64px" size="380px 44px"
+            <Text profile="RF_TreatTargetLine" id="mdDetailPrice" position="770px -64px" size="350px 20px" text=""/>
+            <Text profile="RF_TreatTargetLine" id="mdDetailPressure" position="770px -92px" size="350px 20px" text=""/>
+            <Text profile="RF_HintText" id="mdDetailEmpty" position="770px -64px" size="350px 44px"
                   textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtn" position="770px -280px" size="360px 36px"
+            <Button profile="buttonActivate" id="mdOpenMarketBtn" position="770px -280px" size="350px 36px"
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
 
                         <!-- Page B — Events (fixed Text rows; no SmoothList thrash). -->
-                        <GuiElement id="mdEventsBand" visible="false" position="0px 0px" size="100% 100%">
+                        <GuiElement profile="RF_EscCardFrameWide" id="mdEventsBand" visible="false" position="10px -10px" size="1130px 344px">
                             <Text profile="RF_SectionTitle" id="mdEventsTitle" position="10px -6px" size="700px 22px" text=""/>
                             <Text profile="RF_ColHeader" id="mdEvColName" position="10px -36px" size="420px 20px" text=""/>
                             <Text profile="RF_ColHeader" id="mdEvColIntensity" position="450px -36px" size="220px 20px" text=""/>
@@ -752,12 +809,12 @@
                             <Text profile="RF_TreatTargetLine" id="mdEvMore" position="10px -240px" size="1100px 20px" text=""/>
                             <Text profile="RF_HintText" id="mdEventsEmpty" position="10px -64px" size="1100px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtnEvents" position="770px -280px" size="360px 36px"
+            <Button profile="buttonActivate" id="mdOpenMarketBtnEvents" position="770px -280px" size="350px 36px"
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
 
                         <!-- Page C — Contracts (read-only fixed rows). -->
-                        <GuiElement id="mdContractsBand" visible="false" position="0px 0px" size="100% 100%">
+                        <GuiElement profile="RF_EscCardFrameWide" id="mdContractsBand" visible="false" position="10px -10px" size="1130px 344px">
                             <Text profile="RF_SectionTitle" id="mdContractsTitle" position="10px -6px" size="900px 22px" text=""/>
                             <Text profile="RF_ColHeader" id="mdCtColCrop" position="10px -36px" size="280px 20px" text=""/>
                             <Text profile="RF_ColHeader" id="mdCtColQty" position="300px -36px" size="220px 20px" text=""/>
@@ -786,7 +843,7 @@
                             <Text profile="RF_TreatTargetLine" id="mdCtMore" position="10px -212px" size="1100px 20px" text=""/>
                             <Text profile="RF_HintText" id="mdContractsEmpty" position="10px -64px" size="1100px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtnContracts" position="770px -280px" size="360px 36px"
+            <Button profile="buttonActivate" id="mdOpenMarketBtnContracts" position="770px -280px" size="350px 36px"
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
                     </GuiElement>


### PR DESCRIPTION
## Summary
- Esc-only shared-door freeze: widen Soil PRODUCTS card to 620x248 so PRODUCTS–ROTATION gutters match the 10px family (TREATMENT/ROTATION footprints unchanged).
- Tax only: Status densify FAILFIX (literal GuiUtils reassert every onShow; densify gone).
- Branched clean from live `development`. No `.local/share-staging`, no zip, no gameplay ride-alongs.

## Test plan
- [ ] Esc → RF → Soil: even gaps between the three bottom cards
- [ ] Esc → RF → Tax: Status lines inside the white frame
- [ ] Other RF Esc pages unchanged in behaviour
- [ ] No UTF-8 BOM / UTF-16 on touched files

Replaces the earlier oversized Esc WIP PRs (Sasha CHANGES_REQUESTED on Soil/SCS for deleted shipped APIs / undisclosed pump activatable).