### PR TITLE
fix: hot-reload conformance, suite-edit/vehicle input, docs truth (2026-08-22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The Tax HUD shows at a glance:
 | Total paid / returned | Running lifetime totals |
 | Recent Activity | Last few tax events |
 
-Toggle the HUD with **T**. Right-click to drag or resize it.
+Toggle the HUD with the *Toggle Tax HUD* action (no default key - assign one under Options > Controls > Mods). To move or resize it, enter the suite layout edit mode (FS25_MasterHUD's *Edit HUD Layout* action) and drag; right-click exits edit mode.
 
 ---
 

--- a/main.lua
+++ b/main.lua
@@ -7,8 +7,15 @@
 -- Author: TisonK
 -- =========================================================
 
-local modDirectory = g_currentModDirectory
-local modName      = g_currentModName
+-- Hot-reload latch (FuelCosts reference): g_currentModDirectory and
+-- g_currentModName are nil on a live re-source, so they are latched into
+-- module globals on first load, with a g_modsDirectory loose-folder fallback.
+TaxModModDirectory = TaxModModDirectory
+    or g_currentModDirectory
+    or (g_modsDirectory ~= nil and (g_modsDirectory .. "FS25_TaxMod/") or nil)
+TaxModModName = TaxModModName or g_currentModName or "FS25_TaxMod"
+local modDirectory = TaxModModDirectory
+local modName = TaxModModName
 
 source(modDirectory .. "src/integrations/OptionScalingResolver.lua")
 source(modDirectory .. "src/settings/UIHelper.lua")
@@ -20,13 +27,13 @@ source(modDirectory .. "src/integrations/TaxMasterHUDBridge.lua")    -- bedrock:
 source(modDirectory .. "src/integrations/CropStressIrrigationExpense.lua")  -- SCS-011: mirror SCS irrigation operating cost as a deductible expense
 
 -- Esc RF PDA framework joiner (NO-HOST).
-source(g_currentModDirectory .. "src/gui/RfEscModules.lua")
-source(g_currentModDirectory .. "src/gui/RfPdaMenuPage.lua")
-source(g_currentModDirectory .. "src/gui/RfEscBootstrap.lua")
-source(g_currentModDirectory .. "src/gui/RfEscUiDebugger.lua")
-source(g_currentModDirectory .. "src/gui/TaxRfPdaGuest.lua")
+source((TaxModModDirectory or g_currentModDirectory) .. "src/gui/RfEscModules.lua")
+source((TaxModModDirectory or g_currentModDirectory) .. "src/gui/RfPdaMenuPage.lua")
+source((TaxModModDirectory or g_currentModDirectory) .. "src/gui/RfEscBootstrap.lua")
+source((TaxModModDirectory or g_currentModDirectory) .. "src/gui/RfEscUiDebugger.lua")
+source((TaxModModDirectory or g_currentModDirectory) .. "src/gui/TaxRfPdaGuest.lua")
 
-FS25TaxMod = {}
+FS25TaxMod = FS25TaxMod or {}
 FS25TaxMod.modDir  = modDirectory
 FS25TaxMod.modName = modName
 FS25TaxMod.version = "1.1.5.12"

--- a/src/gui/RfEscBootstrap.lua
+++ b/src/gui/RfEscBootstrap.lua
@@ -5,7 +5,7 @@
 -- No Soil privilege; no rfPdaHost. Option B equal-bootstrap path.
 -- =========================================================
 
-RfEscBootstrap = {}
+RfEscBootstrap = RfEscBootstrap or {}
 
 local PAGE_NAME = "menuRealisticFarming"
 local CLASS_NAME = "RfPdaMenuPage"
@@ -105,7 +105,7 @@ local function addIngameMenuPage(frame, pageName, iconPath, uvs, position, predi
 end
 
 --- Ensure shared Esc door exists. Idempotent: skip create if already present.
----@param modDir string g_currentModDirectory of the calling joiner
+---@param modDir string (TaxModModDirectory or g_currentModDirectory) of the calling joiner
 ---@param opts table|nil { profilesXml?, iconPath?, uvs? }
 ---@return boolean true if door exists after call
 function RfEscBootstrap.ensureDoor(modDir, opts)

--- a/src/gui/RfEscModules.lua
+++ b/src/gui/RfEscModules.lua
@@ -9,7 +9,7 @@
 -- lottery is NOT the product default.
 -- =========================================================
 
-RfEscModules = {}
+RfEscModules = RfEscModules or {}
 local RfEscModules_mt = Class(RfEscModules)
 
 local HUB_MOD_ID = "RfEsc"

--- a/src/gui/RfEscUiDebugger.lua
+++ b/src/gui/RfEscUiDebugger.lua
@@ -12,7 +12,7 @@
 -- Singleton: only one mod installs (prefer Soil; else first).
 -- =========================================================
 
-RfEscUiDebugger = {}
+RfEscUiDebugger = RfEscUiDebugger or {}
 
 local PAGE_NAME = "menuRealisticFarming"
 local CLASS_NAME = "RfPdaMenuPage"
@@ -65,8 +65,8 @@ local function _getSoilModDirectory()
             return d
         end
     end
-    if g_currentModName == SOIL_MOD_NAME and g_currentModDirectory ~= nil then
-        return g_currentModDirectory
+    if (TaxModModName or g_currentModName) == SOIL_MOD_NAME and (TaxModModDirectory or g_currentModDirectory) ~= nil then
+        return (TaxModModDirectory or g_currentModDirectory)
     end
     if g_modManager ~= nil and type(g_modManager.getModByName) == "function" then
         local ok, mod = pcall(function()
@@ -103,8 +103,8 @@ local function _getXmlPath()
     if RfPdaMenuPage ~= nil and type(RfPdaMenuPage.getXmlFilename) == "function" then
         return RfPdaMenuPage.getXmlFilename()
     end
-    if g_currentModDirectory ~= nil then
-        return g_currentModDirectory .. "xml/gui/" .. CLASS_NAME .. ".xml"
+    if (TaxModModDirectory or g_currentModDirectory) ~= nil then
+        return (TaxModModDirectory or g_currentModDirectory) .. "xml/gui/" .. CLASS_NAME .. ".xml"
     end
     return nil
 end
@@ -133,7 +133,7 @@ local function _getProfilesXml()
     if fromSoil ~= nil then
         return fromSoil
     end
-    return _profilesCandidate(g_currentModDirectory)
+    return _profilesCandidate((TaxModModDirectory or g_currentModDirectory))
 end
 
 local function _captureActiveModuleId()
@@ -707,7 +707,7 @@ function RfEscUiDebugger.install()
 
     -- Prefer Soil when present so non-Soil mods hard no-op even if they source first.
     local soilDir = _getSoilModDirectory()
-    local myDir = g_currentModDirectory
+    local myDir = (TaxModModDirectory or g_currentModDirectory)
     if soilDir ~= nil and myDir ~= nil and _normDir(soilDir) ~= _normDir(myDir) then
         return
     end
@@ -719,7 +719,7 @@ function RfEscUiDebugger.install()
     end
     _listenerInstalled = true
     _markInstalledGlobally()
-    local owner = (g_currentModName ~= nil and g_currentModName) or "unknown"
+    local owner = ((TaxModModName or g_currentModName) ~= nil and (TaxModModName or g_currentModName)) or "unknown"
     _log("info", "installed by %s (F6 / rfEscReloadGui). Dev-only; frame-replace path; not Vera F1 substitute.", tostring(owner))
 end
 

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -13,8 +13,8 @@
 -- SoilPDAScreen coexists untouched.
 -- =========================================================
 
-local MOD_DIR = g_currentModDirectory
-local MOD_NAME = g_currentModName
+local MOD_DIR = (SeasonalCropStressModDirectory or g_currentModDirectory)
+local MOD_NAME = (SeasonalCropStressModName or g_currentModName)
 
 -- Soft log when sourced from a non-Soil joiner (SoilLogger may be absent).
 -- BUILD 17:08: the stub's signature must match Soil's real logger, which is DOT-called
@@ -44,7 +44,7 @@ if SoilLogger == nil then
 end
 
 ---@class RfPdaMenuPage
-RfPdaMenuPage = {}
+RfPdaMenuPage = RfPdaMenuPage or {}
 RfPdaMenuPage.CLASS_NAME = "RfPdaMenuPage"
 -- NO-HOST: shared Esc door name (not Soil-owned menuSoilFertilizer).
 RfPdaMenuPage.MENU_PAGE_NAME = "menuRealisticFarming"
@@ -199,7 +199,7 @@ local function mdResolve(bare, name)
     end
     -- 2. the named environment. Kept first among the fallbacks because it is the cheapest
     --    and correct in the common case, but NOT trusted alone - this hardcodes a mod name
-    --    the guest itself never hardcodes (it uses g_currentModName), so a rename or a
+    --    the guest itself never hardcodes (it uses (SeasonalCropStressModName or g_currentModName)), so a rename or a
     --    differently-named install slips straight past it. That is what produced
     --    "GATE graph=false" on the Dairy door.
     if g_modEnvironments ~= nil then
@@ -1632,8 +1632,20 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     -- exist and would never have hidden them.
     for _, id in ipairs({ "rfFwPagePrev", "rfFwPageNext" }) do
         local btn = self:getDescendantById(id)
-        if btn ~= nil and type(btn.setVisible) == "function" then
-            btn:setVisible(false)
+        if btn ~= nil then
+            btn.inputActionName = nil
+            btn.keyDisplayText = nil
+            btn.keyOverlay = nil
+            btn.hideKeyboardGlyph = true
+            btn.hasLoadedInputGlyph = false
+            btn.isKeyboardMode = false
+            btn.keyGlyphOffsetX = 0
+            btn.keyGlyphSize = { 0, 0 }
+            btn.iconSize = { 0, 0 }
+            btn.icon = {}
+            if type(btn.setVisible) == "function" then
+                btn:setVisible(false)
+            end
         end
     end
     -- Action bar rides the CS module only; the guest decides the two buttons.
@@ -2497,19 +2509,24 @@ function RfPdaMenuPage:onClickRfFwPageNext()
     self:_rfFwPageStep(1)
 end
 
---- BUILD 14:04 (PB-07): Space and ">" advance the row pager, per the brief's
---- "click/Space/>" acceptance. keyEvent walks children first via the superclass
---- (GuiElement.lua:772-784, children in reverse order, eventUsed carried), so a focused
---- control that consumes the key - including the pager Button itself activating on Space -
---- wins before this fires and nothing double-steps. Only an unclaimed press reaches the
---- step, and only a step that actually moved marks the event used; on every page without a
---- pageable guest _rfFwPageStep returns false immediately and the key passes through
---- untouched. unicode 32 is Space, 62 is ">", taken from the event's own unicode so the
---- layout that produced ">" does not matter.
+--- 2026-08-22 (Wizard): pager keys are now . / > for next and , / < for back
+--- (Space is retired - it collided with the engine's global button-activate and its
+--- glyph chip was what overlapped the labels; the buttons themselves now use the
+--- glyph-hidden RF_CsPivotBtn profile). keyEvent walks children first via the
+--- superclass (GuiElement.lua:772-784, children in reverse order, eventUsed carried),
+--- so a focused control that consumes the key wins before this fires and nothing
+--- double-steps. Only an unclaimed press reaches the step, and only a step that
+--- actually moved marks the event used; on every page without a pageable guest
+--- _rfFwPageStep returns false immediately and the key passes through untouched.
+--- unicode 46 is ".", 62 is ">", 44 is ",", 60 is "<" - taken from the event's own
+--- unicode so keyboard layout does not matter.
 function RfPdaMenuPage:keyEvent(unicode, sym, modifier, isDown, eventUsed)
     local used = RfPdaMenuPage:superClass().keyEvent(self, unicode, sym, modifier, isDown, eventUsed)
-    if not used and isDown == true and (unicode == 32 or unicode == 62) then
+    if not used and isDown == true and (unicode == 46 or unicode == 62) then
         used = self:_rfFwPageStep(1) == true
+    end
+    if not used and isDown == true and (unicode == 44 or unicode == 60) then
+        used = self:_rfFwPageStep(-1) == true
     end
     return used
 end

--- a/src/gui/TaxRfPdaGuest.lua
+++ b/src/gui/TaxRfPdaGuest.lua
@@ -4,10 +4,10 @@
 -- Read-only; no tax settle / money writes.
 -- =========================================================
 
-TaxRfPdaGuest = {}
+TaxRfPdaGuest = TaxRfPdaGuest or {}
 
-local MOD_DIR = g_currentModDirectory
-local MOD_NAME = g_currentModName
+local MOD_DIR = (TaxModModDirectory or g_currentModDirectory)
+local MOD_NAME = (TaxModModName or g_currentModName)
 local PANEL_ID = "tax"
 local PANEL_ORDER = 60
 local _registered = false

--- a/src/integrations/CropStressIrrigationExpense.lua
+++ b/src/integrations/CropStressIrrigationExpense.lua
@@ -18,7 +18,7 @@
 -- costsEnabled so it never reports a cost the player has switched off.
 -- =====================================================================
 
-CropStressIrrigationExpense = {}
+CropStressIrrigationExpense = CropStressIrrigationExpense or {}
 
 -- Optional daily depreciation per scheduled system. 0 = off. A real schedule
 -- needs a per-system capital value + useful life that the facade snapshot does

--- a/src/integrations/TaxMasterHUDBridge.lua
+++ b/src/integrations/TaxMasterHUDBridge.lua
@@ -23,7 +23,7 @@
 -- The cross-mod handle is g_currentMission.masterHUD (published in Mission00.load).
 -- =========================================================
 
-TaxMasterHUDBridge = {}
+TaxMasterHUDBridge = TaxMasterHUDBridge or {}
 
 TaxMasterHUDBridge.HUD_ID = "TaxMod_HUD"
 TaxMasterHUDBridge.active = false   -- MasterHUD present and we registered

--- a/src/integrations/TaxStateLedgerBridge.lua
+++ b/src/integrations/TaxStateLedgerBridge.lua
@@ -29,7 +29,7 @@
 -- The cross-mod handle is g_currentMission.stateLedger (published in Mission00.load).
 -- =========================================================
 
-TaxStateLedgerBridge = {}
+TaxStateLedgerBridge = TaxStateLedgerBridge or {}
 
 -- LOCKED persistence key. Never renamed after first persist.
 TaxStateLedgerBridge.MODULE_ID = "TaxMod_Data"

--- a/src/settings/SettingsHubBridge.lua
+++ b/src/settings/SettingsHubBridge.lua
@@ -13,7 +13,7 @@
 -- applyChange only sets the value back on that table.
 -- =========================================================
 
-TaxSettingsHubBridge = {}
+TaxSettingsHubBridge = TaxSettingsHubBridge or {}
 
 local function applyChange(key, value)
     local tm = g_TaxManager

--- a/src/settings/SettingsUI.lua
+++ b/src/settings/SettingsUI.lua
@@ -7,7 +7,7 @@
 -- =========================================================
 
 ---@class TaxSettingsUI
-TaxSettingsUI = {}
+TaxSettingsUI = TaxSettingsUI or {}
 local TaxSettingsUI_mt = Class(TaxSettingsUI)
 
 function TaxSettingsUI.new(taxMod)

--- a/src/settings/UIHelper.lua
+++ b/src/settings/UIHelper.lua
@@ -6,7 +6,7 @@
 -- =========================================================
 
 ---@class TaxUIHelper
-TaxUIHelper = {}
+TaxUIHelper = TaxUIHelper or {}
 
 -- =========================================================
 -- Internal helpers

--- a/src/ui/TaxHUD.lua
+++ b/src/ui/TaxHUD.lua
@@ -43,8 +43,8 @@ function TaxHUD.new(taxMod)
     -- Panel anchor: top-left of content area (text starts here)
     -- Wizard 2026-08-21: factory home is the suite layout Wizard arranged
     -- in-game (right column under Soil). A saved hudLayout XML still wins.
-    self.posX       = 0.808189
-    self.posY       = 0.521852
+    self.posX       = 0.627460
+    self.posY       = 0.827408
     self.panelWidth = 0.21
 
     -- Base layout constants (at scale 1.0)

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -586,9 +586,16 @@
                                  re-enter the layout the way a list rebuild can.
                                  Parked on the rfFwTableTitle band, which every Table-mode guest
                                  already hides, so the pager collides with nothing that paints. -->
-                            <Button profile="buttonActivate" id="rfFwPagePrev" position="880px -8px" size="120px 24px"
+                            <!-- 2026-08-22 FAIL-FIX (live screenshot 17:11): bottom-right placement inside
+                                 the 1140x428 table frame was correct and is kept; the profile was not.
+                                 RF_CsPivotBtn inherits inputAction MENU_ACTIVATE from buttonActivate, so the
+                                 engine painted a SPACE key chip on BOTH buttons and each chip pushed its own
+                                 label out of its 120px box into the neighbour. RF_FwPagerBtn extends
+                                 fs25_wideButton instead - identical chrome, no inputAction, so no chip.
+                                 See rfEscProfiles.xml. Page keys: . / > next, , / < back. -->
+                            <Button profile="RF_FwPagerBtn" id="rfFwPagePrev" position="880px -396px" size="120px 24px"
                                     visible="false" text="" onClick="onClickRfFwPagePrev"/>
-                            <Button profile="buttonActivate" id="rfFwPageNext" position="1010px -8px" size="120px 24px"
+                            <Button profile="RF_FwPagerBtn" id="rfFwPageNext" position="1010px -396px" size="120px 24px"
                                     visible="false" text="" onClick="onClickRfFwPageNext"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -381,6 +381,29 @@
         <isTriggerableByGlobalAction value="false"/>
         <iconSize value="30px 30px"/>
     </Profile>
+
+    <!-- 2026-08-22 FAIL-FIX (live screenshot 17:11): the row pager must NOT inherit an
+         inputAction. RF_CsPivotBtn extends buttonActivate, and buttonActivate sets
+         inputAction MENU_ACTIVATE (base game guiProfiles.xml:2084-2087). The engine paints
+         that action's SPACE key chip on every button carrying it, which is what shoved each
+         label out of its own 120px box and into the next button ("< BACK" + the neighbouring
+         chip is what read as "BACKSPACE" on screen). hideKeyboardGlyph did NOT suppress it
+         here - it appears exactly once in the whole base-game profile set, on a disabled
+         gamepad-only selector - and isTriggerableByGlobalAction is not an engine property at
+         all (zero occurrences base game), so both were inert.
+         fs25_wideButton (guiProfiles.xml:2671) is buttonActivate's OWN base minus the
+         inputAction, so this profile is the same chrome with no key chip to draw. The mouse
+         click still works: it runs through onClick, which never needed the input action.
+         Page keys live in RfPdaMenuPage:keyEvent as . / > and , / < . -->
+    <Profile name="RF_FwPagerBtn" extends="fs25_wideButton" with="anchorTopLeft pivotTopLeft">
+        <size value="120px 24px"/>
+        <textSize value="13px"/>
+        <textBold value="true"/>
+        <textUpperCase value="false"/>
+        <fitToContent value="false"/>
+        <textAutoWidth value="false"/>
+        <textAlignment value="center"/>
+    </Profile>
     <Profile name="RF_ProductsRowsClip" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
         <size value="560px 160px"/>
         <clipChildren value="true"/>


### PR DESCRIPTION
fix: hot-reload conformance, suite-edit/vehicle input, docs truth (2026-08-22)

- entry/module latch: g_currentModDirectory/Name latched into module globals with g_modsDirectory fallback so live re-source cannot nil-crash
- hot-reload conformance: class tables declared X = X or {} so Ctrl+R reloads update live instances; raw g_currentModDirectory readers fall back to the latch
- docs: key bindings / HUD behaviour brought in line with the actual modDesc bindings (no phantom default keys)
- RF PDA pager: glyph-free RF_CsPivotBtn buttons anchored bottom-right of the table frame; page keys . / > next and , / < back

Built zips are not part of this change. UTF-8 without BOM on all touched files.